### PR TITLE
feat: Add DTO validation and enhanced exception handling (#23)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     // Spring Boot WebFlux
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Spring Data R2DBC
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/AccountController.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/AccountController.kt
@@ -6,6 +6,7 @@ import com.labs.ledger.adapter.`in`.web.dto.DepositRequest
 import com.labs.ledger.domain.port.CreateAccountUseCase
 import com.labs.ledger.domain.port.DepositUseCase
 import com.labs.ledger.domain.port.GetAccountBalanceUseCase
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
@@ -19,7 +20,7 @@ class AccountController(
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    suspend fun createAccount(@RequestBody request: CreateAccountRequest): AccountResponse {
+    suspend fun createAccount(@Valid @RequestBody request: CreateAccountRequest): AccountResponse {
         val account = createAccountUseCase.execute(request.ownerName)
         return AccountResponse.from(account)
     }
@@ -27,7 +28,7 @@ class AccountController(
     @PostMapping("/{id}/deposits")
     suspend fun deposit(
         @PathVariable id: Long,
-        @RequestBody request: DepositRequest
+        @Valid @RequestBody request: DepositRequest
     ): AccountResponse {
         val account = depositUseCase.execute(id, request.amount, request.description)
         return AccountResponse.from(account)

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
@@ -3,6 +3,7 @@ package com.labs.ledger.adapter.`in`.web
 import com.labs.ledger.adapter.`in`.web.dto.TransferRequest
 import com.labs.ledger.adapter.`in`.web.dto.TransferResponse
 import com.labs.ledger.domain.port.TransferUseCase
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ServerWebExchange
@@ -16,7 +17,7 @@ class TransferController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     suspend fun transfer(
-        @RequestBody request: TransferRequest,
+        @Valid @RequestBody request: TransferRequest,
         exchange: ServerWebExchange
     ): TransferResponse {
         val idempotencyKey = exchange.request.headers.getFirst("Idempotency-Key")
@@ -24,8 +25,8 @@ class TransferController(
 
         val transfer = transferUseCase.execute(
             idempotencyKey = idempotencyKey,
-            fromAccountId = request.fromAccountId,
-            toAccountId = request.toAccountId,
+            fromAccountId = request.fromAccountId!!,
+            toAccountId = request.toAccountId!!,
             amount = request.amount,
             description = request.description
         )

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/AccountDto.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/AccountDto.kt
@@ -1,14 +1,18 @@
 package com.labs.ledger.adapter.`in`.web.dto
 
 import com.labs.ledger.domain.model.Account
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class CreateAccountRequest(
+    @field:NotBlank(message = "Owner name must not be blank")
     val ownerName: String
 )
 
 data class DepositRequest(
+    @field:Positive(message = "Amount must be positive")
     val amount: BigDecimal,
     val description: String? = null
 )

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/ErrorResponse.kt
@@ -1,9 +1,18 @@
 package com.labs.ledger.adapter.`in`.web.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.LocalDateTime
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
     val error: String,
     val message: String,
+    val errors: List<FieldError>? = null,
     val timestamp: LocalDateTime = LocalDateTime.now()
+)
+
+data class FieldError(
+    val field: String,
+    val message: String,
+    val rejectedValue: Any? = null
 )

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/TransferDto.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/TransferDto.kt
@@ -1,12 +1,17 @@
 package com.labs.ledger.adapter.`in`.web.dto
 
 import com.labs.ledger.domain.model.Transfer
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
 data class TransferRequest(
-    val fromAccountId: Long,
-    val toAccountId: Long,
+    @field:NotNull(message = "From account ID is required")
+    val fromAccountId: Long?,
+    @field:NotNull(message = "To account ID is required")
+    val toAccountId: Long?,
+    @field:Positive(message = "Amount must be positive")
     val amount: BigDecimal,
     val description: String? = null
 )


### PR DESCRIPTION
## Summary

웹 어댑터 레이어의 공통 처리를 개선하여 DTO 입력 검증과 예외 처리를 강화했습니다.

### Changes

#### 1. Dependencies
- ✅ `spring-boot-starter-validation` 추가

#### 2. DTO Validation
- ✅ `@NotBlank` for `CreateAccountRequest.ownerName`
- ✅ `@Positive` for `DepositRequest.amount`
- ✅ `@NotNull` for `TransferRequest.fromAccountId/toAccountId`
- ✅ `@Positive` for `TransferRequest.amount`
- ✅ `@Valid` annotation on all controller request parameters

#### 3. Error Response Enhancement
- ✅ `FieldError` data class for field-level validation details
- ✅ `errors: List<FieldError>?` field in `ErrorResponse`
- ✅ `@JsonInclude(NON_NULL)` for backward compatibility

#### 4. Exception Handlers
- ✅ `WebExchangeBindException` → 400 VALIDATION_FAILED (with field errors)
- ✅ `InvalidTransferStatusTransitionException` → 409 INVALID_TRANSFER_STATUS_TRANSITION

#### 5. Tests
- ✅ Validation failure test for blank ownerName
- ✅ Validation failure tests for zero/negative amounts
- ✅ Validation failure tests for null account IDs
- ✅ Invalid transfer status transition test
- ✅ Updated existing tests to match new validation behavior

### Test Results

```
./gradlew test
BUILD SUCCESSFUL

./gradlew koverVerify
BUILD SUCCESSFUL (coverage >= 70%)
```

### Design Decisions

1. **Success Response Wrapper**: Not implemented - kept bare DTO responses for REST conventions and backward compatibility
2. **DTO Validation vs Domain Validation**: Both layers maintained
   - DTO validation = Input format/structure checks
   - Domain `require()` = Business rule validation (defensive layer)
3. **WebFlux-specific**: Uses `WebExchangeBindException` instead of `MethodArgumentNotValidException`

## Test Plan

- [x] All existing tests pass
- [x] New validation tests pass
- [x] Coverage threshold maintained (>= 70%)
- [x] Manual API testing with invalid requests

## Related Issue

Closes #23

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)