### PR TITLE
feat: Add Spring Boot Actuator and health checks (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,79 @@ server:
 - 컨테이너 재시작 시 데이터 손실 방지
 - 이체 트랜잭션 중 강제 종료 방지
 
+### Actuator & Health Check
+
+운영 환경에서 애플리케이션 상태를 모니터링할 수 있는 엔드포인트를 제공합니다.
+
+**사용 가능한 엔드포인트:**
+
+| Endpoint | Method | 설명 | Dev | Prod |
+|----------|--------|------|-----|------|
+| `/actuator/health` | GET | 헬스체크 (DB, 디스크 등) | ✅ | ✅ |
+| `/actuator/health/liveness` | GET | Liveness probe (K8s) | ✅ | ✅ |
+| `/actuator/health/readiness` | GET | Readiness probe (K8s) | ✅ | ✅ |
+| `/actuator/info` | GET | 빌드 정보 (버전, 시간) | ✅ | ✅ |
+| `/actuator/metrics` | GET | 메트릭 목록 | ✅ | ❌ |
+
+**Health Check 응답 예시:**
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "db": {
+      "status": "UP",
+      "details": {
+        "database": "PostgreSQL",
+        "validationQuery": "isValid()"
+      }
+    },
+    "diskSpace": {
+      "status": "UP"
+    },
+    "ping": {
+      "status": "UP"
+    }
+  }
+}
+```
+
+**Build Info 응답 예시:**
+```bash
+curl http://localhost:8080/actuator/info
+```
+
+```json
+{
+  "build": {
+    "artifact": "account-ledger-service",
+    "name": "account-ledger-service",
+    "version": "0.0.1-SNAPSHOT",
+    "group": "com.labs"
+  }
+}
+```
+
+**Kubernetes Probes:**
+```yaml
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 5
+```
+
 ## API 엔드포인트
 
 ### 엔드포인트 요약

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     // Spring Boot WebFlux
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     // Spring Data R2DBC
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
@@ -78,6 +79,11 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+// Generate build-info for Actuator /info endpoint
+springBoot {
+    buildInfo()
 }
 
 kover {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,6 +32,15 @@ spring:
 server:
   shutdown: graceful
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info  # Restrict to essential endpoints only
+  endpoint:
+    health:
+      show-details: never  # Hide sensitive details in production
+
 logging:
   level:
     com.labs.ledger: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,26 @@ server:
   netty:
     connection-timeout: 10s  # Connection establishment timeout
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+      probes:
+        enabled: true
+  health:
+    defaults:
+      enabled: true
+  info:
+    env:
+      enabled: true
+    build:
+      enabled: true
+
 logging:
   pattern:
     console: "%d{HH:mm:ss.SSS} [%X{traceId:-}] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
## Summary
Closes #41

운영 환경에서 애플리케이션 상태를 모니터링할 수 있도록 Spring Boot Actuator를 추가합니다.

## Features

### Health Check Endpoints
- **`/actuator/health`** - 전체 헬스 상태
- **`/actuator/health/liveness`** - Kubernetes Liveness Probe
- **`/actuator/health/readiness`** - Kubernetes Readiness Probe

### Info Endpoint
- **`/actuator/info`** - 빌드 정보 (버전, 빌드 시간 등)

### Metrics Endpoint
- **`/actuator/metrics`** - 애플리케이션 메트릭 (Dev 환경만)

## Configuration

### Development (application.yml)
```yaml
management:
  endpoints:
    web:
      exposure:
        include: health,info,metrics  # 모든 엔드포인트 노출
  endpoint:
    health:
      show-details: when-authorized  # 인증 시 상세 정보
```

### Production (application-prod.yml)
```yaml
management:
  endpoints:
    web:
      exposure:
        include: health,info  # 필수 엔드포인트만
  endpoint:
    health:
      show-details: never  # 상세 정보 숨김 (보안)
```

## Health Check Components

Actuator는 다음 컴포넌트를 자동으로 체크합니다:

| Component | Description | Auto-detected |
|-----------|-------------|---------------|
| `db` | Database connectivity (R2DBC) | ✅ |
| `diskSpace` | Disk space availability | ✅ |
| `ping` | Application alive | ✅ |

**Health Response Example:**
```bash
curl http://localhost:8080/actuator/health
```

```json
{
  "status": "UP",
  "groups": ["liveness", "readiness"]
}
```

**With Details (Dev):**
```json
{
  "status": "UP",
  "components": {
    "db": {
      "status": "UP",
      "details": {
        "database": "PostgreSQL",
        "validationQuery": "isValid()"
      }
    },
    "diskSpace": {
      "status": "UP",
      "details": {
        "total": 500000000000,
        "free": 250000000000,
        "threshold": 10485760
      }
    }
  }
}
```

## Build Information

**Info Response:**
```bash
curl http://localhost:8080/actuator/info
```

```json
{
  "build": {
    "artifact": "account-ledger-service",
    "name": "account-ledger-service",
    "time": "2026-02-13T12:05:54.341Z",
    "version": "0.0.1-SNAPSHOT",
    "group": "com.labs"
  }
}
```

## Kubernetes Integration

### Liveness Probe
```yaml
livenessProbe:
  httpGet:
    path: /actuator/health/liveness
    port: 8080
  initialDelaySeconds: 30
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 3
```

**Purpose:** 애플리케이션이 살아있는지 확인. 실패 시 컨테이너 재시작.

### Readiness Probe
```yaml
readinessProbe:
  httpGet:
    path: /actuator/health/readiness
    port: 8080
  initialDelaySeconds: 20
  periodSeconds: 5
  timeoutSeconds: 3
  failureThreshold: 3
```

**Purpose:** 애플리케이션이 트래픽을 받을 준비가 되었는지 확인. 실패 시 트래픽 차단.

## Benefits

### Monitoring & Observability
- 🏥 **Health Monitoring**: 실시간 애플리케이션 상태 확인
- 📊 **Metrics**: 성능 지표 수집 (CPU, Memory, HTTP 요청 등)
- 🔍 **Traceability**: 배포 버전 및 빌드 정보 추적

### Production Readiness
- ☸️ **Kubernetes Native**: Liveness/Readiness probes 지원
- 🔒 **Security**: 프로덕션에서 민감한 정보 숨김
- 🚨 **Alerting**: 헬스체크 실패 시 자동 알림 가능

### DevOps Integration
- 📈 **Prometheus**: Metrics 엔드포인트를 Prometheus로 스크래핑 가능
- 📊 **Grafana**: 대시보드 구성 가능
- 🔔 **Alerting**: Health 상태 기반 알림 설정

## Security Considerations

### Development
- ✅ 모든 엔드포인트 노출 (디버깅 편의)
- ✅ 상세 정보 표시
- ✅ Metrics 접근 가능

### Production
- ⚠️ 필수 엔드포인트만 노출 (health, info)
- 🔒 상세 정보 숨김 (보안)
- ❌ Metrics 비활성화 (DDoS 방지)

## Verification

### Endpoint Tests
```bash
# Health check
curl http://localhost:8080/actuator/health
✅ {"status":"UP","groups":["liveness","readiness"]}

# Build info
curl http://localhost:8080/actuator/info
✅ {"build":{"artifact":"account-ledger-service","version":"0.0.1-SNAPSHOT"}}

# Liveness probe
curl http://localhost:8080/actuator/health/liveness
✅ {"status":"UP"}

# Readiness probe
curl http://localhost:8080/actuator/health/readiness
✅ {"status":"UP"}
```

### Build & Test
```bash
./gradlew clean build
✅ BUILD SUCCESSFUL in 23s
✅ bootBuildInfo task executed
✅ All tests pass
✅ Coverage: 93.53%
```

## Next Steps

### Short-term
- [ ] Configure custom health indicators (e.g., external API checks)
- [ ] Add custom metrics (e.g., transfer success rate)

### Long-term
- [ ] Integrate with Prometheus + Grafana
- [ ] Set up alerting rules
- [ ] Add distributed tracing (Zipkin/Jaeger)

## Related Issues
- Part of Phase 1 infrastructure improvements
- Complements #37 (Graceful Shutdown)
- Foundation for monitoring and observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)