### PR TITLE
feat: Add server-side retry mechanism for optimistic lock conflicts (#43)

### DIFF
--- a/src/main/kotlin/com/labs/ledger/infrastructure/util/RetryUtil.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/util/RetryUtil.kt
@@ -1,0 +1,53 @@
+package com.labs.ledger.infrastructure.util
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
+import org.springframework.dao.OptimisticLockingFailureException
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Retry utility for handling optimistic locking conflicts in coroutine context.
+ *
+ * Automatically retries the given block when OptimisticLockingFailureException is thrown.
+ * Uses exponential backoff strategy between retries.
+ *
+ * @param maxAttempts Maximum number of attempts (default: 3)
+ * @param block The suspending function to retry
+ * @return The result of the successful execution
+ * @throws OptimisticLockingFailureException if all retry attempts are exhausted
+ */
+suspend fun <T> retryOnOptimisticLock(
+    maxAttempts: Int = 3,
+    block: suspend () -> T
+): T {
+    require(maxAttempts > 0) { "maxAttempts must be positive" }
+
+    repeat(maxAttempts - 1) { attempt ->
+        try {
+            return block()
+        } catch (e: OptimisticLockingFailureException) {
+            val attemptNumber = attempt + 1
+            logger.warn { "Optimistic lock conflict, retrying... (attempt $attemptNumber/$maxAttempts)" }
+
+            // Exponential backoff: 0ms, 100ms, 200ms
+            val delayMs = when (attempt) {
+                0 -> 0L      // 1st retry: immediate
+                1 -> 100L    // 2nd retry: 100ms delay
+                else -> 200L // 3rd+ retry: 200ms delay
+            }
+
+            if (delayMs > 0) {
+                delay(delayMs)
+            }
+        }
+    }
+
+    // Last attempt without catching exception
+    return try {
+        block()
+    } catch (e: OptimisticLockingFailureException) {
+        logger.error { "Optimistic lock conflict exhausted all $maxAttempts attempts" }
+        throw e
+    }
+}


### PR DESCRIPTION
## Summary
Optimistic Lock 충돌 시 서버 측에서 자동 재시도를 수행하여 사용자 경험을 개선합니다.

## Changes
### 1. RetryUtil.kt (신규)
- 코루틴 기반 retry 유틸리티 구현
- 최대 3회 재시도 (지수 백오프: 0ms → 100ms → 200ms)
- `OptimisticLockingFailureException` 감지 시 자동 재시도
- 재시도 시도마다 WARN 로그 기록
- 모든 재시도 소진 시 예외를 상위로 전파 (→ 409 Conflict)

### 2. DepositService.kt
- `retryOnOptimisticLock`으로 트랜잭션 실행 감싸기
- 동시 입금 시 자동 재시도

### 3. TransferService.kt
- `retryOnOptimisticLock`으로 트랜잭션 실행 감싸기
- 명시적 레이블 추가 (`@retry`, `@tx`) - 레이블 충돌 방지
- 동시 이체 시 자동 재시도

## Benefits
✅ 사용자 경험 개선 (수동 재시도 불필요)
✅ 중간 동시성 환경에서 409 에러 감소
✅ Optimistic Locking으로 데이터 일관성 유지

## Test Results
```
./gradlew clean build
BUILD SUCCESSFUL

./gradlew koverLog
application line coverage: 81.85%
```

## Acceptance Criteria
- [x] Optimistic Lock 충돌 시 최대 3회까지 자동 재시도
- [x] 재시도 성공 시 정상 응답 반환
- [x] 3회 모두 실패 시 409 Conflict 반환
- [x] 로그에 재시도 시도가 기록됨
- [x] 기존 테스트가 모두 통과함

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)