### PR TITLE
chore: Adjust Kover coverage scope to include adapters (#48)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,6 @@ kover {
                     "*Configuration",
                     "*.dto.*",
                     "*.entity.*",
-                    "*.adapter.*",
                     "*Application*"
                 )
             }


### PR DESCRIPTION
## Summary
Kover 커버리지 측정 범위를 조정하여 Controller와 PersistenceAdapter를 포함시켰습니다.

## Changes
- `build.gradle.kts`: `*.adapter.*` 제외 패턴 제거
- 이제 Controller와 PersistenceAdapter가 커버리지 측정에 포함됩니다
- 제외 대상: DTO, Entity, Configuration, Application 클래스만 유지

## Impact
- 실제 비즈니스 로직이 포함된 Adapter 계층의 커버리지 측정 가능
- 더 정확한 전체 코드 커버리지 파악

## Test Status
⚠️ **Note**: 통합 테스트가 공유 DB 환경 문제로 실패하지만, Kover 설정 변경 자체는 올바르게 적용되었습니다.
- 단위 테스트: ✅ 정상 통과
- 통합 테스트: ❌ 환경 문제 (DB 격리 이슈)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)