### PR TITLE
feat: Add Dockerfile and GitHub Actions CI/CD (#38)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Build outputs
+build/
+target/
+out/
+*.jar
+*.war
+*.class
+
+# Gradle
+.gradle/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDE
+.idea/
+.vscode/
+.settings/
+*.iml
+*.ipr
+*.iws
+.project
+.classpath
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Documentation
+*.md
+docs/
+
+# Test and coverage
+coverage/
+test-results/
+build/reports/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+*.swp
+*~

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: ledger
+          POSTGRES_USER: ledger
+          POSTGRES_PASSWORD: ledger123
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests with coverage
+        env:
+          SPRING_R2DBC_URL: r2dbc:postgresql://localhost:5432/ledger
+          SPRING_R2DBC_USERNAME: ledger
+          SPRING_R2DBC_PASSWORD: ledger123
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/ledger
+          SPRING_DATASOURCE_USERNAME: ledger
+          SPRING_DATASOURCE_PASSWORD: ledger123
+        run: ./gradlew clean test koverHtmlReport koverLog
+
+      - name: Verify coverage threshold
+        run: ./gradlew koverVerify
+
+      - name: Build JAR
+        run: ./gradlew bootJar
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: build/reports/kover/html/
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: build/reports/tests/test/
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const coverageLog = fs.readFileSync('build/reports/kover/log.txt', 'utf8');
+
+            const body = `## 📊 Coverage Report\n\n\`\`\`\n${coverageLog}\n\`\`\``;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: account-ledger-service:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test Docker image
+        run: |
+          docker images account-ledger-service:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Stage 1: Build
+FROM eclipse-temurin:21-jdk-jammy AS builder
+
+WORKDIR /app
+
+# Copy Gradle wrapper and configuration files
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# Download dependencies (cached layer)
+RUN ./gradlew dependencies --no-daemon
+
+# Copy source code
+COPY src src
+
+# Build the application
+RUN ./gradlew bootJar --no-daemon && \
+    mv build/libs/*.jar app.jar
+
+# Stage 2: Runtime
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+# Create non-root user
+RUN groupadd -r spring && useradd -r -g spring spring
+
+# Copy JAR from builder
+COPY --from=builder /app/app.jar app.jar
+
+# Change ownership
+RUN chown spring:spring app.jar
+
+# Switch to non-root user
+USER spring:spring
+
+# Expose port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -126,6 +126,50 @@ export JDBC_URL=jdbc:postgresql://prod-host:5432/ledger
 http://localhost:8080
 ```
 
+### Docker로 실행
+
+**Docker 이미지 빌드**
+```bash
+docker build -t account-ledger-service:latest .
+```
+
+**PostgreSQL과 함께 실행 (Docker Compose 사용)**
+```bash
+# PostgreSQL + 애플리케이션 모두 시작
+docker compose up -d
+
+# 로그 확인
+docker compose logs -f app
+
+# 종료
+docker compose down
+```
+
+**단독 실행 (PostgreSQL이 이미 실행 중인 경우)**
+```bash
+docker run -d \
+  --name account-ledger-service \
+  -p 8080:8080 \
+  -e SPRING_PROFILES_ACTIVE=prod \
+  -e DB_USERNAME=ledger \
+  -e DB_PASSWORD=ledger123 \
+  -e R2DBC_URL=r2dbc:postgresql://host.docker.internal:5432/ledger \
+  -e JDBC_URL=jdbc:postgresql://host.docker.internal:5432/ledger \
+  account-ledger-service:latest
+```
+
+**헬스체크**
+```bash
+# 애플리케이션 상태 확인
+curl http://localhost:8080/actuator/health
+
+# Liveness probe
+curl http://localhost:8080/actuator/health/liveness
+
+# Readiness probe
+curl http://localhost:8080/actuator/health/readiness
+```
+
 ### 프로파일별 설정
 
 | 프로파일 | 용도 | 로깅 레벨 | R2DBC Pool | 특징 |


### PR DESCRIPTION
## Summary
컨테이너 기반 배포와 자동화된 CI/CD 파이프라인을 구축하였습니다.

## Changes

### 1. **Dockerfile** (Multi-stage Build)
- **Build Stage**: Eclipse Temurin JDK 21 + Gradle wrapper
  - Dependencies caching layer 분리 (빌드 최적화)
  - Source code layer 분리
  - `bootJar` 빌드
- **Runtime Stage**: Eclipse Temurin JRE 21 (경량화)
  - 비root 사용자 실행 (`spring:spring`)
  - Health check 포함 (`/actuator/health`)
  - 이미지 크기: 549MB (압축 170MB)

### 2. **.dockerignore**
- 빌드 컨텍스트 최적화 (build/, .git/, IDE 설정 제외)
- 불필요한 파일 전송 방지

### 3. **GitHub Actions CI** (`.github/workflows/ci.yml`)
- **테스트 실행**:
  - PostgreSQL 서비스 컨테이너 사용
  - 통합 테스트 포함 전체 테스트 실행
  - Kover 커버리지 리포트 생성
  - 커버리지 threshold 검증 (70%)
- **아티팩트**:
  - Coverage HTML 리포트 업로드
  - Test 리포트 업로드
- **PR 코멘트**:
  - 커버리지 결과를 PR에 자동 코멘트
- **Docker 빌드**:
  - main 브랜치 push 시 Docker 이미지 빌드
  - BuildKit cache 사용 (빌드 최적화)

### 4. **README.md**
- Docker 실행 가이드 추가
  - Docker 이미지 빌드
  - Docker Compose로 실행
  - 단독 실행 (환경변수 설정)
  - 헬스체크 예시

## Test Results

### Docker Build
```
✅ Build successful: 549MB (170MB compressed)
✅ Multi-stage build working
✅ Health check configured
✅ Non-root user (spring:spring)
```

### CI Workflow
- PostgreSQL service 설정 완료
- 환경변수 주입 설정 완료
- Kover 커버리지 자동화 완료

## Impact
- 🐳 컨테이너 기반 배포 지원
- 🤖 자동화된 테스트 및 커버리지 검증
- 📊 PR에 커버리지 리포트 자동 표시
- 🚀 빌드 캐싱으로 CI 시간 단축

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)