### PR TITLE
feat: Add pagination support for ledger entries (#49)

### DIFF
--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageRequest.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageRequest.kt
@@ -1,0 +1,18 @@
+package com.labs.ledger.adapter.`in`.web.dto
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+data class PageRequest(
+    @field:Min(value = 0, message = "Page number must be 0 or greater")
+    val page: Int = 0,
+
+    @field:Min(value = 1, message = "Page size must be at least 1")
+    @field:Max(value = 100, message = "Page size must not exceed 100")
+    val size: Int = 20,
+
+    val sort: String? = null
+) {
+    val offset: Long
+        get() = page.toLong() * size
+}

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageResponse.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageResponse.kt
@@ -1,0 +1,34 @@
+package com.labs.ledger.adapter.`in`.web.dto
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+    val hasNext: Boolean,
+    val hasPrevious: Boolean
+) {
+    companion object {
+        fun <T> of(
+            content: List<T>,
+            page: Int,
+            size: Int,
+            totalElements: Long
+        ): PageResponse<T> {
+            val totalPages = if (totalElements == 0L) 0 else ((totalElements - 1) / size + 1).toInt()
+            val hasNext = page < totalPages - 1
+            val hasPrevious = page > 0
+
+            return PageResponse(
+                content = content,
+                page = page,
+                size = size,
+                totalElements = totalElements,
+                totalPages = totalPages,
+                hasNext = hasNext,
+                hasPrevious = hasPrevious
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/LedgerEntryPersistenceAdapter.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/LedgerEntryPersistenceAdapter.kt
@@ -31,6 +31,16 @@ class LedgerEntryPersistenceAdapter(
             .toList()
     }
 
+    override suspend fun findByAccountId(accountId: Long, offset: Long, limit: Int): List<LedgerEntry> {
+        return repository.findByAccountIdWithPagination(accountId, offset, limit)
+            .map { toDomain(it) }
+            .toList()
+    }
+
+    override suspend fun countByAccountId(accountId: Long): Long {
+        return repository.countByAccountId(accountId)
+    }
+
     private fun toEntity(domain: LedgerEntry): LedgerEntryEntity {
         return LedgerEntryEntity(
             id = domain.id,

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/LedgerEntryEntityRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/LedgerEntryEntityRepository.kt
@@ -2,10 +2,22 @@ package com.labs.ledger.adapter.out.persistence.repository
 
 import com.labs.ledger.adapter.out.persistence.entity.LedgerEntryEntity
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface LedgerEntryEntityRepository : CoroutineCrudRepository<LedgerEntryEntity, Long> {
     fun findByAccountId(accountId: Long): Flow<LedgerEntryEntity>
+
+    @Query("""
+        SELECT * FROM ledger_entry
+        WHERE account_id = :accountId
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    fun findByAccountIdWithPagination(accountId: Long, offset: Long, limit: Int): Flow<LedgerEntryEntity>
+
+    @Query("SELECT COUNT(*) FROM ledger_entry WHERE account_id = :accountId")
+    suspend fun countByAccountId(accountId: Long): Long
 }

--- a/src/main/kotlin/com/labs/ledger/application/port/in/GetLedgerEntriesUseCase.kt
+++ b/src/main/kotlin/com/labs/ledger/application/port/in/GetLedgerEntriesUseCase.kt
@@ -1,0 +1,14 @@
+package com.labs.ledger.application.port.`in`
+
+import com.labs.ledger.domain.model.LedgerEntry
+
+data class LedgerEntriesPage(
+    val entries: List<LedgerEntry>,
+    val totalElements: Long,
+    val page: Int,
+    val size: Int
+)
+
+interface GetLedgerEntriesUseCase {
+    suspend fun execute(accountId: Long, page: Int, size: Int): LedgerEntriesPage
+}

--- a/src/main/kotlin/com/labs/ledger/application/service/GetLedgerEntriesService.kt
+++ b/src/main/kotlin/com/labs/ledger/application/service/GetLedgerEntriesService.kt
@@ -1,0 +1,35 @@
+package com.labs.ledger.application.service
+
+import com.labs.ledger.application.port.`in`.GetLedgerEntriesUseCase
+import com.labs.ledger.application.port.`in`.LedgerEntriesPage
+import com.labs.ledger.domain.exception.AccountNotFoundException
+import com.labs.ledger.domain.port.AccountRepository
+import com.labs.ledger.domain.port.LedgerEntryRepository
+import org.springframework.stereotype.Service
+
+@Service
+class GetLedgerEntriesService(
+    private val accountRepository: AccountRepository,
+    private val ledgerEntryRepository: LedgerEntryRepository
+) : GetLedgerEntriesUseCase {
+
+    override suspend fun execute(accountId: Long, page: Int, size: Int): LedgerEntriesPage {
+        // Validate account exists
+        accountRepository.findById(accountId)
+            ?: throw AccountNotFoundException("Account not found: $accountId")
+
+        // Calculate offset
+        val offset = page.toLong() * size
+
+        // Fetch paginated entries and total count
+        val entries = ledgerEntryRepository.findByAccountId(accountId, offset, size)
+        val totalElements = ledgerEntryRepository.countByAccountId(accountId)
+
+        return LedgerEntriesPage(
+            entries = entries,
+            totalElements = totalElements,
+            page = page,
+            size = size
+        )
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/domain/port/LedgerEntryRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/domain/port/LedgerEntryRepository.kt
@@ -6,4 +6,8 @@ interface LedgerEntryRepository {
     suspend fun save(entry: LedgerEntry): LedgerEntry
     suspend fun saveAll(entries: List<LedgerEntry>): List<LedgerEntry>
     suspend fun findByAccountId(accountId: Long): List<LedgerEntry>
+
+    // Pagination support
+    suspend fun findByAccountId(accountId: Long, offset: Long, limit: Int): List<LedgerEntry>
+    suspend fun countByAccountId(accountId: Long): Long
 }

--- a/src/test/kotlin/com/labs/ledger/application/service/GetLedgerEntriesServiceTest.kt
+++ b/src/test/kotlin/com/labs/ledger/application/service/GetLedgerEntriesServiceTest.kt
@@ -1,0 +1,156 @@
+package com.labs.ledger.application.service
+
+import com.labs.ledger.domain.exception.AccountNotFoundException
+import com.labs.ledger.domain.model.Account
+import com.labs.ledger.domain.model.AccountStatus
+import com.labs.ledger.domain.model.LedgerEntry
+import com.labs.ledger.domain.model.LedgerEntryType
+import com.labs.ledger.domain.port.AccountRepository
+import com.labs.ledger.domain.port.LedgerEntryRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class GetLedgerEntriesServiceTest {
+
+    private val accountRepository: AccountRepository = mockk()
+    private val ledgerEntryRepository: LedgerEntryRepository = mockk()
+    private val service = GetLedgerEntriesService(accountRepository, ledgerEntryRepository)
+
+    @Test
+    fun `페이지네이션된 원장 조회 성공`() = runTest {
+        // given
+        val accountId = 1L
+        val page = 0
+        val size = 10
+        val offset = 0L
+
+        val account = Account(
+            id = accountId,
+            ownerName = "Test User",
+            balance = BigDecimal("1000.00"),
+            status = AccountStatus.ACTIVE
+        )
+
+        val entries = listOf(
+            LedgerEntry(
+                id = 1L,
+                accountId = accountId,
+                type = LedgerEntryType.CREDIT,
+                amount = BigDecimal("100.00"),
+                referenceId = "ref1",
+                description = "Deposit",
+                createdAt = LocalDateTime.now()
+            ),
+            LedgerEntry(
+                id = 2L,
+                accountId = accountId,
+                type = LedgerEntryType.DEBIT,
+                amount = BigDecimal("50.00"),
+                referenceId = "ref2",
+                description = "Withdrawal",
+                createdAt = LocalDateTime.now()
+            )
+        )
+
+        coEvery { accountRepository.findById(accountId) } returns account
+        coEvery { ledgerEntryRepository.findByAccountId(accountId, offset, size) } returns entries
+        coEvery { ledgerEntryRepository.countByAccountId(accountId) } returns 25L
+
+        // when
+        val result = service.execute(accountId, page, size)
+
+        // then
+        assert(result.entries.size == 2)
+        assert(result.totalElements == 25L)
+        assert(result.page == 0)
+        assert(result.size == 10)
+
+        coVerify { accountRepository.findById(accountId) }
+        coVerify { ledgerEntryRepository.findByAccountId(accountId, offset, size) }
+        coVerify { ledgerEntryRepository.countByAccountId(accountId) }
+    }
+
+    @Test
+    fun `존재하지 않는 계좌로 조회 시 예외 발생`() = runTest {
+        // given
+        val accountId = 999L
+        coEvery { accountRepository.findById(accountId) } returns null
+
+        // when & then
+        assertThrows<AccountNotFoundException> {
+            service.execute(accountId, 0, 10)
+        }
+    }
+
+    @Test
+    fun `두 번째 페이지 조회`() = runTest {
+        // given
+        val accountId = 1L
+        val page = 1
+        val size = 10
+        val offset = 10L
+
+        val account = Account(
+            id = accountId,
+            ownerName = "Test User",
+            balance = BigDecimal("1000.00"),
+            status = AccountStatus.ACTIVE
+        )
+
+        val entries = listOf(
+            LedgerEntry(
+                id = 11L,
+                accountId = accountId,
+                type = LedgerEntryType.CREDIT,
+                amount = BigDecimal("100.00"),
+                referenceId = "ref11",
+                description = "Deposit",
+                createdAt = LocalDateTime.now()
+            )
+        )
+
+        coEvery { accountRepository.findById(accountId) } returns account
+        coEvery { ledgerEntryRepository.findByAccountId(accountId, offset, size) } returns entries
+        coEvery { ledgerEntryRepository.countByAccountId(accountId) } returns 25L
+
+        // when
+        val result = service.execute(accountId, page, size)
+
+        // then
+        assert(result.page == 1)
+        assert(result.entries.size == 1)
+        coVerify { ledgerEntryRepository.findByAccountId(accountId, offset, size) }
+    }
+
+    @Test
+    fun `빈 결과 조회`() = runTest {
+        // given
+        val accountId = 1L
+        val page = 0
+        val size = 10
+
+        val account = Account(
+            id = accountId,
+            ownerName = "Test User",
+            balance = BigDecimal("0.00"),
+            status = AccountStatus.ACTIVE
+        )
+
+        coEvery { accountRepository.findById(accountId) } returns account
+        coEvery { ledgerEntryRepository.findByAccountId(accountId, 0L, size) } returns emptyList()
+        coEvery { ledgerEntryRepository.countByAccountId(accountId) } returns 0L
+
+        // when
+        val result = service.execute(accountId, page, size)
+
+        // then
+        assert(result.entries.isEmpty())
+        assert(result.totalElements == 0L)
+    }
+}


### PR DESCRIPTION
## Summary
원장 조회에 페이지네이션 지원을 추가하여 대량 데이터 조회 성능을 개선하였습니다.

## Changes

### 1. **Pagination DTOs**
- **PageRequest**: 페이징 요청 파라미터
  - `page`: 페이지 번호 (default: 0, min: 0)
  - `size`: 페이지 크기 (default: 20, range: 1-100)
  - `sort`: 정렬 기준 (optional)
  - `offset` property: 자동 계산 (page * size)
  - Jakarta Validation annotations 포함

- **PageResponse<T>**: 제네릭 페이징 응답
  - `content`: 조회된 데이터 리스트
  - `page`, `size`: 페이징 파라미터
  - `totalElements`: 전체 항목 수
  - `totalPages`: 전체 페이지 수
  - `hasNext`, `hasPrevious`: 페이지 존재 여부
  - Factory method `of()` 제공

### 2. **Domain Port Extension**
**LedgerEntryRepository**:
```kotlin
suspend fun findByAccountId(accountId: Long, offset: Long, limit: Int): List<LedgerEntry>
suspend fun countByAccountId(accountId: Long): Long
```

### 3. **Persistence Layer**
**LedgerEntryEntityRepository**:
- Custom `@Query` with `LIMIT/OFFSET`
- `ORDER BY created_at DESC` (최신 순)
- `COUNT(*)` query for total elements

**LedgerEntryPersistenceAdapter**:
- Repository 메서드 구현
- Entity → Domain 변환

### 4. **Application Layer**
**GetLedgerEntriesUseCase**: 새로운 유스케이스
- `LedgerEntriesPage` 데이터 클래스
- 페이징 결과 + 메타데이터

**GetLedgerEntriesService**: 서비스 구현
- 계좌 존재 여부 검증
- 페이지네이션 조회 실행
- 전체 개수 조회

### 5. **Tests**
**GetLedgerEntriesServiceTest**: 4개 테스트
- ✅ 페이지네이션된 원장 조회 성공
- ✅ 존재하지 않는 계좌로 조회 시 예외 발생
- ✅ 두 번째 페이지 조회
- ✅ 빈 결과 조회

## Test Results
```
GetLedgerEntriesServiceTest
  ✅ 페이지네이션된 원장 조회 성공
  ✅ 존재하지 않는 계좌로 조회 시 예외 발생
  ✅ 두 번째 페이지 조회
  ✅ 빈 결과 조회

4 tests passed
```

## Performance Impact
- 📊 **Before**: `SELECT * FROM ledger_entry WHERE account_id = ?` (모든 레코드)
- ⚡ **After**: `LIMIT 20 OFFSET 0` (필요한 만큼만)
- 🚀 대량 원장 데이터가 있는 계좌에서 성능 개선

## Architecture
```
Controller (Issue #50에서 추가)
    ↓
GetLedgerEntriesUseCase (NEW)
    ↓
GetLedgerEntriesService (NEW)
    ↓
LedgerEntryRepository (pagination methods added)
    ↓
LedgerEntryPersistenceAdapter (pagination implementation)
    ↓
LedgerEntryEntityRepository (@Query with LIMIT/OFFSET)
```

## Next Steps
Issue #50에서 다음 작업 진행:
- Controller 엔드포인트 추가 (`GET /api/accounts/{id}/ledger-entries`)
- LedgerEntryResponse DTO 작성
- API 통합 테스트

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)