### PR TITLE
feat: Add list query endpoints for accounts, ledger, and transfers (#50)

### DIFF
--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
@@ -1,7 +1,7 @@
 package com.labs.ledger.adapter.`in`.web
 
-import com.labs.ledger.adapter.`in`.web.dto.TransferRequest
-import com.labs.ledger.adapter.`in`.web.dto.TransferResponse
+import com.labs.ledger.adapter.`in`.web.dto.*
+import com.labs.ledger.application.port.`in`.GetTransfersUseCase
 import com.labs.ledger.domain.port.TransferUseCase
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -11,8 +11,18 @@ import org.springframework.web.server.ServerWebExchange
 @RestController
 @RequestMapping("/api/transfers")
 class TransferController(
-    private val transferUseCase: TransferUseCase
+    private val transferUseCase: TransferUseCase,
+    private val getTransfersUseCase: GetTransfersUseCase
 ) {
+
+    @GetMapping
+    suspend fun getTransfers(
+        @Valid @ModelAttribute pageRequest: com.labs.ledger.adapter.`in`.web.dto.PageRequest = com.labs.ledger.adapter.`in`.web.dto.PageRequest()
+    ): PageResponse<TransferResponse> {
+        val page = getTransfersUseCase.execute(pageRequest.page, pageRequest.size)
+        val content = page.transfers.map { TransferResponse.from(it) }
+        return PageResponse.of(content, page.page, page.size, page.totalElements)
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/LedgerEntryResponse.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/LedgerEntryResponse.kt
@@ -1,0 +1,30 @@
+package com.labs.ledger.adapter.`in`.web.dto
+
+import com.labs.ledger.domain.model.LedgerEntry
+import com.labs.ledger.domain.model.LedgerEntryType
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class LedgerEntryResponse(
+    val id: Long?,
+    val accountId: Long,
+    val type: LedgerEntryType,
+    val amount: BigDecimal,
+    val referenceId: String?,
+    val description: String?,
+    val createdAt: LocalDateTime?
+) {
+    companion object {
+        fun from(ledgerEntry: LedgerEntry): LedgerEntryResponse {
+            return LedgerEntryResponse(
+                id = ledgerEntry.id,
+                accountId = ledgerEntry.accountId,
+                type = ledgerEntry.type,
+                amount = ledgerEntry.amount,
+                referenceId = ledgerEntry.referenceId,
+                description = ledgerEntry.description,
+                createdAt = ledgerEntry.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/AccountPersistenceAdapter.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/AccountPersistenceAdapter.kt
@@ -6,6 +6,8 @@ import com.labs.ledger.domain.exception.OptimisticLockException
 import com.labs.ledger.domain.model.Account
 import com.labs.ledger.domain.model.AccountStatus
 import com.labs.ledger.domain.port.AccountRepository
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.stereotype.Component
 
@@ -34,6 +36,16 @@ class AccountPersistenceAdapter(
 
     override suspend fun findByIdsForUpdate(ids: List<Long>): List<Account> {
         return repository.findByIdsForUpdate(ids).map { toDomain(it) }
+    }
+
+    override suspend fun findAll(offset: Long, limit: Int): List<Account> {
+        return repository.findAllWithPagination(offset, limit)
+            .map { toDomain(it) }
+            .toList()
+    }
+
+    override suspend fun count(): Long {
+        return repository.count()
     }
 
     private fun toEntity(domain: Account): AccountEntity {

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/TransferPersistenceAdapter.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/TransferPersistenceAdapter.kt
@@ -5,6 +5,8 @@ import com.labs.ledger.adapter.out.persistence.repository.TransferEntityReposito
 import com.labs.ledger.domain.model.Transfer
 import com.labs.ledger.domain.model.TransferStatus
 import com.labs.ledger.domain.port.TransferRepository
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Component
 
 @Component
@@ -20,6 +22,16 @@ class TransferPersistenceAdapter(
 
     override suspend fun findByIdempotencyKey(idempotencyKey: String): Transfer? {
         return repository.findByIdempotencyKey(idempotencyKey)?.let { toDomain(it) }
+    }
+
+    override suspend fun findAll(offset: Long, limit: Int): List<Transfer> {
+        return repository.findAllWithPagination(offset, limit)
+            .map { toDomain(it) }
+            .toList()
+    }
+
+    override suspend fun count(): Long {
+        return repository.count()
     }
 
     private fun toEntity(domain: Transfer): TransferEntity {

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/AccountEntityRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/AccountEntityRepository.kt
@@ -1,6 +1,7 @@
 package com.labs.ledger.adapter.out.persistence.repository
 
 import com.labs.ledger.adapter.out.persistence.entity.AccountEntity
+import kotlinx.coroutines.flow.Flow
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
@@ -18,4 +19,11 @@ interface AccountEntityRepository : CoroutineCrudRepository<AccountEntity, Long>
         FOR UPDATE
     """)
     suspend fun findByIdsForUpdate(ids: Collection<Long>): List<AccountEntity>
+
+    @Query("""
+        SELECT * FROM accounts
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    fun findAllWithPagination(offset: Long, limit: Int): Flow<AccountEntity>
 }

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/TransferEntityRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/TransferEntityRepository.kt
@@ -1,10 +1,19 @@
 package com.labs.ledger.adapter.out.persistence.repository
 
 import com.labs.ledger.adapter.out.persistence.entity.TransferEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface TransferEntityRepository : CoroutineCrudRepository<TransferEntity, Long> {
     suspend fun findByIdempotencyKey(idempotencyKey: String): TransferEntity?
+
+    @Query("""
+        SELECT * FROM transfers
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    fun findAllWithPagination(offset: Long, limit: Int): Flow<TransferEntity>
 }

--- a/src/main/kotlin/com/labs/ledger/application/port/in/GetAccountsUseCase.kt
+++ b/src/main/kotlin/com/labs/ledger/application/port/in/GetAccountsUseCase.kt
@@ -1,0 +1,14 @@
+package com.labs.ledger.application.port.`in`
+
+import com.labs.ledger.domain.model.Account
+
+data class AccountsPage(
+    val accounts: List<Account>,
+    val totalElements: Long,
+    val page: Int,
+    val size: Int
+)
+
+interface GetAccountsUseCase {
+    suspend fun execute(page: Int, size: Int): AccountsPage
+}

--- a/src/main/kotlin/com/labs/ledger/application/port/in/GetTransfersUseCase.kt
+++ b/src/main/kotlin/com/labs/ledger/application/port/in/GetTransfersUseCase.kt
@@ -1,0 +1,14 @@
+package com.labs.ledger.application.port.`in`
+
+import com.labs.ledger.domain.model.Transfer
+
+data class TransfersPage(
+    val transfers: List<Transfer>,
+    val totalElements: Long,
+    val page: Int,
+    val size: Int
+)
+
+interface GetTransfersUseCase {
+    suspend fun execute(page: Int, size: Int): TransfersPage
+}

--- a/src/main/kotlin/com/labs/ledger/application/service/GetAccountsService.kt
+++ b/src/main/kotlin/com/labs/ledger/application/service/GetAccountsService.kt
@@ -1,0 +1,25 @@
+package com.labs.ledger.application.service
+
+import com.labs.ledger.application.port.`in`.AccountsPage
+import com.labs.ledger.application.port.`in`.GetAccountsUseCase
+import com.labs.ledger.domain.port.AccountRepository
+import org.springframework.stereotype.Service
+
+@Service
+class GetAccountsService(
+    private val accountRepository: AccountRepository
+) : GetAccountsUseCase {
+
+    override suspend fun execute(page: Int, size: Int): AccountsPage {
+        val offset = page.toLong() * size
+        val accounts = accountRepository.findAll(offset, size)
+        val totalElements = accountRepository.count()
+
+        return AccountsPage(
+            accounts = accounts,
+            totalElements = totalElements,
+            page = page,
+            size = size
+        )
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/application/service/GetTransfersService.kt
+++ b/src/main/kotlin/com/labs/ledger/application/service/GetTransfersService.kt
@@ -1,0 +1,25 @@
+package com.labs.ledger.application.service
+
+import com.labs.ledger.application.port.`in`.GetTransfersUseCase
+import com.labs.ledger.application.port.`in`.TransfersPage
+import com.labs.ledger.domain.port.TransferRepository
+import org.springframework.stereotype.Service
+
+@Service
+class GetTransfersService(
+    private val transferRepository: TransferRepository
+) : GetTransfersUseCase {
+
+    override suspend fun execute(page: Int, size: Int): TransfersPage {
+        val offset = page.toLong() * size
+        val transfers = transferRepository.findAll(offset, size)
+        val totalElements = transferRepository.count()
+
+        return TransfersPage(
+            transfers = transfers,
+            totalElements = totalElements,
+            page = page,
+            size = size
+        )
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/domain/port/AccountRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/domain/port/AccountRepository.kt
@@ -7,4 +7,8 @@ interface AccountRepository {
     suspend fun findById(id: Long): Account?
     suspend fun findByIdForUpdate(id: Long): Account?
     suspend fun findByIdsForUpdate(ids: List<Long>): List<Account>
+
+    // Pagination support
+    suspend fun findAll(offset: Long, limit: Int): List<Account>
+    suspend fun count(): Long
 }

--- a/src/main/kotlin/com/labs/ledger/domain/port/TransferRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/domain/port/TransferRepository.kt
@@ -5,4 +5,8 @@ import com.labs.ledger.domain.model.Transfer
 interface TransferRepository {
     suspend fun save(transfer: Transfer): Transfer
     suspend fun findByIdempotencyKey(idempotencyKey: String): Transfer?
+
+    // Pagination support
+    suspend fun findAll(offset: Long, limit: Int): List<Transfer>
+    suspend fun count(): Long
 }


### PR DESCRIPTION
## Summary
계좌, 원장, 이체 이력을 조회할 수 있는 페이지네이션 기반 목록 조회 API를 추가하였습니다.

## Changes

### 1. **GET /api/accounts** - 계좌 목록 조회
**Domain Layer:**
- `AccountRepository`: 페이지네이션 메서드 추가
  - `findAll(offset: Long, limit: Int): List<Account>`
  - `count(): Long`

**Application Layer:**
- `GetAccountsUseCase`: 새로운 유스케이스
- `AccountsPage`: 응답 데이터 클래스
- `GetAccountsService`: 페이지네이션 서비스 구현

**Persistence Layer:**
- `AccountEntityRepository.findAllWithPagination()`: R2DBC custom query
  ```sql
  SELECT * FROM accounts
  ORDER BY created_at DESC
  LIMIT :limit OFFSET :offset
  ```
- `AccountPersistenceAdapter`: Flow → List 변환

**Web Layer:**
- `AccountController.getAccounts()`: GET 엔드포인트
- Query parameters: `page` (default: 0), `size` (default: 20)

### 2. **GET /api/accounts/{id}/ledger-entries** - 원장 조회
**DTO:**
- `LedgerEntryResponse`: LedgerEntry → Response 변환

**Web Layer:**
- `AccountController.getLedgerEntries()`: GET 엔드포인트
- Uses `GetLedgerEntriesUseCase` (from Issue #49)

### 3. **GET /api/transfers** - 이체 이력 조회
**Domain Layer:**
- `TransferRepository`: 페이지네이션 메서드 추가
  - `findAll(offset: Long, limit: Int): List<Transfer>`
  - `count(): Long`

**Application Layer:**
- `GetTransfersUseCase`: 새로운 유스케이스
- `TransfersPage`: 응답 데이터 클래스
- `GetTransfersService`: 페이지네이션 서비스 구현

**Persistence Layer:**
- `TransferEntityRepository.findAllWithPagination()`: R2DBC custom query
  ```sql
  SELECT * FROM transfers
  ORDER BY created_at DESC
  LIMIT :limit OFFSET :offset
  ```
- `TransferPersistenceAdapter`: Flow → List 변환

**Web Layer:**
- `TransferController.getTransfers()`: GET 엔드포인트

## API Usage

### 1. Get Accounts
```bash
curl "http://localhost:8080/api/accounts?page=0&size=20"
```

**Response:**
```json
{
  "content": [
    {
      "id": 1,
      "ownerName": "John Doe",
      "balance": 1000.00,
      "status": "ACTIVE",
      "version": 0
    }
  ],
  "page": 0,
  "size": 20,
  "totalElements": 50,
  "totalPages": 3,
  "hasNext": true,
  "hasPrevious": false
}
```

### 2. Get Ledger Entries
```bash
curl "http://localhost:8080/api/accounts/1/ledger-entries?page=0&size=10"
```

**Response:**
```json
{
  "content": [
    {
      "id": 1,
      "accountId": 1,
      "type": "CREDIT",
      "amount": 100.00,
      "referenceId": "ref1",
      "description": "Deposit"
    }
  ],
  "page": 0,
  "size": 10,
  "totalElements": 25,
  "totalPages": 3,
  "hasNext": true,
  "hasPrevious": false
}
```

### 3. Get Transfers
```bash
curl "http://localhost:8080/api/transfers?page=0&size=20"
```

**Response:**
```json
{
  "content": [
    {
      "id": 1,
      "idempotencyKey": "key-001",
      "fromAccountId": 1,
      "toAccountId": 2,
      "amount": 500.00,
      "status": "COMPLETED"
    }
  ],
  "page": 0,
  "size": 20,
  "totalElements": 100,
  "totalPages": 5,
  "hasNext": true,
  "hasPrevious": false
}
```

## Architecture Consistency

All endpoints follow the same pattern:

```
Controller (GET /{resource})
    ↓ @ModelAttribute PageRequest
GetXxxUseCase
    ↓ execute(page, size)
GetXxxService
    ↓ repository.findAll(offset, limit)
XxxRepository Port
    ↓ Custom @Query
XxxEntityRepository
    ↓ LIMIT/OFFSET
Database
```

## Impact
- 📊 **Complete CRUD**: All major entities now have list APIs
- ⚡ **Performance**: Offset-based pagination prevents large data loads
- 🔍 **Consistency**: All use PageResponse<T> structure
- ✅ **Scalable**: Ready to add filters and advanced sorting

## Dependencies
- Built on Issue #49 pagination infrastructure
- Uses existing PageRequest and PageResponse DTOs

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)