### PR TITLE
fix: Add missing @MockkBean for controller tests (#71)

### DIFF
--- a/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
+++ b/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
@@ -5,6 +5,8 @@ import com.labs.ledger.domain.exception.InvalidAccountStatusException
 import com.labs.ledger.domain.exception.InvalidAmountException
 import com.labs.ledger.domain.model.Account
 import com.labs.ledger.domain.model.AccountStatus
+import com.labs.ledger.application.port.`in`.GetAccountsUseCase
+import com.labs.ledger.application.port.`in`.GetLedgerEntriesUseCase
 import com.labs.ledger.domain.port.CreateAccountUseCase
 import com.labs.ledger.domain.port.DepositUseCase
 import com.labs.ledger.domain.port.GetAccountBalanceUseCase
@@ -34,6 +36,12 @@ class AccountControllerTest {
 
     @MockkBean
     private lateinit var getAccountBalanceUseCase: GetAccountBalanceUseCase
+
+    @MockkBean
+    private lateinit var getAccountsUseCase: GetAccountsUseCase
+
+    @MockkBean
+    private lateinit var getLedgerEntriesUseCase: GetLedgerEntriesUseCase
 
     @Test
     fun `계좌 생성 성공 - 201 Created`() = runTest {

--- a/src/test/kotlin/com/labs/ledger/adapter/in/web/TransferControllerTest.kt
+++ b/src/test/kotlin/com/labs/ledger/adapter/in/web/TransferControllerTest.kt
@@ -1,5 +1,6 @@
 package com.labs.ledger.adapter.`in`.web
 
+import com.labs.ledger.application.port.`in`.GetTransfersUseCase
 import com.labs.ledger.domain.exception.AccountNotFoundException
 import com.labs.ledger.domain.exception.DuplicateTransferException
 import com.labs.ledger.domain.exception.InvalidTransferStatusTransitionException
@@ -26,6 +27,9 @@ class TransferControllerTest {
 
     @MockkBean
     private lateinit var transferUseCase: TransferUseCase
+
+    @MockkBean
+    private lateinit var getTransfersUseCase: GetTransfersUseCase
 
     @Test
     fun `이체 성공 - 201 Created`() = runTest {


### PR DESCRIPTION
## Summary
- ✅ Add `GetAccountsUseCase` and `GetLedgerEntriesUseCase` to `AccountControllerTest`
- ✅ Add `GetTransfersUseCase` to `TransferControllerTest`

## Problem
After PR #70 (commit `cd13d54`), new UseCases were added to controllers but corresponding `@MockkBean` declarations were missing in test files, causing 20 controller tests to fail in CI.

## Root Cause
- `AccountController` added dependencies on `GetAccountsUseCase` and `GetLedgerEntriesUseCase`
- `TransferController` added dependency on `GetTransfersUseCase`
- Test files were not updated with matching `@MockkBean` declarations

## Solution
Added missing `@MockkBean` declarations:

### AccountControllerTest.kt
```kotlin
@MockkBean
private lateinit var getAccountsUseCase: GetAccountsUseCase

@MockkBean
private lateinit var getLedgerEntriesUseCase: GetLedgerEntriesUseCase
```

### TransferControllerTest.kt
```kotlin
@MockkBean
private lateinit var getTransfersUseCase: GetTransfersUseCase
```

## Test Results
```bash
./gradlew test --tests "AccountControllerTest" --tests "TransferControllerTest"
# ✅ BUILD SUCCESSFUL
```

## Impact
- **Fixed**: 20 controller tests now pass
- **Remaining**: Issue #72 (19 integration/concurrency tests) - separate fix required

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)