### PR TITLE
chore: R2DBC PostgreSQL 의존성 버전 고정 제거 및 scope 변경 (#75)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     // Spring Data R2DBC
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-    implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+    runtimeOnly("org.postgresql:r2dbc-postgresql")
 
     // Flyway (requires JDBC for migrations)
     implementation("org.springframework.boot:spring-boot-starter-jdbc")  // Required for Flyway auto-configuration


### PR DESCRIPTION
## 변경 내용

`build.gradle.kts`에서 R2DBC PostgreSQL 드라이버 의존성 선언 개선:

```diff
- implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+ runtimeOnly("org.postgresql:r2dbc-postgresql")
```

## 목적

### 1. 명시적 버전 고정 제거
- Spring Boot 3.4.2 BOM이 `1.0.7.RELEASE`를 관리하고 있음
- 향후 Spring Boot 업그레이드 시 자동으로 호환 버전 적용
- 보안 패치 및 버그 수정 자동 반영

### 2. scope 변경 (implementation → runtimeOnly)
- R2DBC 드라이버는 런타임에만 필요
- JDBC 드라이버(`org.postgresql:postgresql`)와 동일한 패턴 적용
- 불필요한 컴파일 의존성 노출 방지

## 검증

### 의존성 버전 확인
```bash
$ ./gradlew dependencies --configuration runtimeClasspath | grep r2dbc-postgresql
+--- org.postgresql:r2dbc-postgresql -> 1.0.7.RELEASE
```
✅ Spring Boot BOM이 1.0.7.RELEASE를 자동으로 선택

### 빌드 성공
```bash
$ ./gradlew clean build
BUILD SUCCESSFUL
```
✅ 컴파일 성공

### 패턴 일관성
```kotlin
// JDBC 드라이버 (기존)
runtimeOnly("org.postgresql:postgresql")

// R2DBC 드라이버 (수정 후)
runtimeOnly("org.postgresql:r2dbc-postgresql")
```
✅ 동일한 역할의 드라이버는 동일한 scope 적용

## 참고

- Closes #75
- 관련 이슈: #75 (R2DBC PostgreSQL 의존성 개선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)