### PR TITLE
fix: Add missing @MockkBean for UpdateAccountStatusUseCase (#78)

### DIFF
--- a/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
+++ b/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
@@ -10,6 +10,7 @@ import com.labs.ledger.application.port.`in`.GetLedgerEntriesUseCase
 import com.labs.ledger.domain.port.CreateAccountUseCase
 import com.labs.ledger.domain.port.DepositUseCase
 import com.labs.ledger.domain.port.GetAccountBalanceUseCase
+import com.labs.ledger.domain.port.UpdateAccountStatusUseCase
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
@@ -42,6 +43,9 @@ class AccountControllerTest {
 
     @MockkBean
     private lateinit var getLedgerEntriesUseCase: GetLedgerEntriesUseCase
+
+    @MockkBean
+    private lateinit var updateAccountStatusUseCase: UpdateAccountStatusUseCase
 
     @Test
     fun `계좌 생성 성공 - 201 Created`() = runTest {


### PR DESCRIPTION
## 문제

PR #76 머지 후 **main 브랜치 CI 실패** 발생.

### 실패 내용
- AccountControllerTest: 9개 테스트 전체 실패
- 에러: `NoSuchBeanDefinitionException: No qualifying bean of type 'UpdateAccountStatusUseCase'`

## 원인

PR #76에서 `AccountController`에 `UpdateAccountStatusUseCase` 의존성을 추가했으나,  
`AccountControllerTest`에서 해당 Bean을 **@MockkBean으로 선언하지 않음**.

## 해결

### 변경사항

```diff
+ import com.labs.ledger.domain.port.UpdateAccountStatusUseCase

  @MockkBean
  private lateinit var getLedgerEntriesUseCase: GetLedgerEntriesUseCase

+ @MockkBean
+ private lateinit var updateAccountStatusUseCase: UpdateAccountStatusUseCase
```

## 검증

### 로컬 테스트
```bash
$ ./gradlew test --tests "AccountControllerTest"
BUILD SUCCESSFUL ✅

$ ./gradlew clean test
BUILD SUCCESSFUL ✅
```

### 영향 범위
- ✅ AccountControllerTest: 9개 → 0개 실패
- ✅ 전체 테스트: 통과

## 우선순위

**P0 - Critical**: main 브랜치 CI 차단 중

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)