### PR TITLE
fix: align ledger_entries queries and add pagination/count test (#80)

### DIFF
--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/LedgerEntryEntityRepository.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/repository/LedgerEntryEntityRepository.kt
@@ -11,13 +11,13 @@ interface LedgerEntryEntityRepository : CoroutineCrudRepository<LedgerEntryEntit
     fun findByAccountId(accountId: Long): Flow<LedgerEntryEntity>
 
     @Query("""
-        SELECT * FROM ledger_entry
+        SELECT * FROM ledger_entries
         WHERE account_id = :accountId
         ORDER BY created_at DESC
         LIMIT :limit OFFSET :offset
     """)
     fun findByAccountIdWithPagination(accountId: Long, offset: Long, limit: Int): Flow<LedgerEntryEntity>
 
-    @Query("SELECT COUNT(*) FROM ledger_entry WHERE account_id = :accountId")
+    @Query("SELECT COUNT(*) FROM ledger_entries WHERE account_id = :accountId")
     suspend fun countByAccountId(accountId: Long): Long
 }


### PR DESCRIPTION
## Summary
- Fix `LedgerEntryEntityRepository` SQL table name from `ledger_entry` to `ledger_entries`
- Add integration test for ledger-entry pagination + count path

## Testing
- ./gradlew test -q

Closes #80