### PR TITLE
fix: return 409 for idempotency-key unique violations (#81)

### DIFF
--- a/src/test/kotlin/com/labs/ledger/adapter/in/web/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/labs/ledger/adapter/in/web/GlobalExceptionHandlerTest.kt
@@ -1,12 +1,11 @@
 package com.labs.ledger.adapter.`in`.web
 
-import com.labs.ledger.adapter.`in`.web.dto.ErrorResponse
 import com.labs.ledger.domain.exception.*
 import org.junit.jupiter.api.Test
 import org.springframework.dao.DataAccessException
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.support.WebExchangeBindException
 import org.springframework.web.server.MethodNotAllowedException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebInputException
@@ -94,6 +93,34 @@ class GlobalExceptionHandlerTest {
         assert(response.statusCode == HttpStatus.BAD_REQUEST)
         assert(response.body?.error == "INVALID_INPUT")
         assert(response.body?.message?.contains("Invalid JSON") == true)
+    }
+
+    @Test
+    fun `DataIntegrityViolationException 처리 - idempotency key 중복`() {
+        // given
+        val exception = DataIntegrityViolationException(
+            "duplicate key value violates unique constraint \"transfers_idempotency_key_key\""
+        )
+
+        // when
+        val response = handler.handleDataIntegrityViolationException(exception)
+
+        // then
+        assert(response.statusCode == HttpStatus.CONFLICT)
+        assert(response.body?.error == "DUPLICATE_TRANSFER")
+    }
+
+    @Test
+    fun `DataIntegrityViolationException 처리 - 일반 제약 위반은 DB 오류`() {
+        // given
+        val exception = DataIntegrityViolationException("violates check constraint check_amount_positive")
+
+        // when
+        val response = handler.handleDataIntegrityViolationException(exception)
+
+        // then
+        assert(response.statusCode == HttpStatus.SERVICE_UNAVAILABLE)
+        assert(response.body?.error == "DATABASE_ERROR")
     }
 
     @Test
@@ -208,6 +235,7 @@ class GlobalExceptionHandlerTest {
             InsufficientBalanceException("test"),
             IllegalArgumentException("test"),
             ServerWebInputException("test"),
+            DataIntegrityViolationException("duplicate key value violates unique constraint \"transfers_idempotency_key_key\""),
             object : DataAccessException("test") {},
             RuntimeException("test")
         )
@@ -218,6 +246,7 @@ class GlobalExceptionHandlerTest {
                 is AccountNotFoundException -> handler.handleDomainException(exception)
                 is IllegalArgumentException -> handler.handleIllegalArgument(exception)
                 is ServerWebInputException -> handler.handleServerWebInputException(exception)
+                is DataIntegrityViolationException -> handler.handleDataIntegrityViolationException(exception)
                 is DataAccessException -> handler.handleDataAccessException(exception)
                 else -> handler.handleGenericException(exception)
             }


### PR DESCRIPTION
## Summary
- Add `DataIntegrityViolationException` handling in `GlobalExceptionHandler`
- Map idempotency-key unique constraint violations to `DUPLICATE_TRANSFER (409)`
- Keep generic DB failures mapped to `DATABASE_ERROR (503)`
- Add handler tests for both duplicate and generic integrity violations

## Testing
- ./gradlew test -q

Closes #81