### PR TITLE
docs: sync Docker Compose setup with README guide (#82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,14 @@ DB_NAME=ledger
 DB_USERNAME=ledger
 DB_PASSWORD=ledger123
 
-# R2DBC URL
+# Application
+APP_PORT=8080
+SPRING_PROFILES_ACTIVE=prod
+
+# R2DBC URL (for local bootRun)
 # Format: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 R2DBC_URL=r2dbc:postgresql://localhost:5432/ledger
 
-# JDBC URL (for Flyway)
+# JDBC URL (for Flyway, local bootRun)
 # Format: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 JDBC_URL=jdbc:postgresql://localhost:5432/ledger

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cp .env.example .env
 
 2. PostgreSQL 실행
 ```bash
-docker compose up -d
+docker compose up -d postgres
 ```
 
 3. 애플리케이션 실행

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,22 @@ services:
       timeout: 5s
       retries: 5
 
+  app:
+    build:
+      context: .
+    image: account-ledger-service:latest
+    container_name: account-ledger-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+      DB_USERNAME: ${DB_USERNAME:-ledger}
+      DB_PASSWORD: ${DB_PASSWORD:-ledger123}
+      R2DBC_URL: r2dbc:postgresql://postgres:5432/${DB_NAME:-ledger}
+      JDBC_URL: jdbc:postgresql://postgres:5432/${DB_NAME:-ledger}
+
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary
- Add `app` service to `docker-compose.yml`
- Sync README startup step for DB-only bootstrap (`docker compose up -d postgres`)
- Update `.env.example` with app runtime vars

## Testing
- Configuration/docs changes reviewed

Closes #82