### PR TITLE
ops: ensure runtime healthcheck dependency is present (#83)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
+# Install healthcheck dependency
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create non-root user
 RUN groupadd -r spring && useradd -r -g spring spring
 


### PR DESCRIPTION
## Summary
- Install `curl` explicitly in runtime image to make HEALTHCHECK deterministic

## Testing
- Dockerfile change reviewed

Closes #83