### PR TITLE
refactor: remove unused sort parameter from PageRequest (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,54 @@ curl -X POST http://localhost:8080/api/transfers \
 }
 ```
 
+### 5. 페이지네이션 (리스트 조회)
+
+모든 리스트 조회 API는 페이지네이션을 지원하며, **created_at DESC (최신순)** 으로 고정 정렬됩니다.
+
+**지원 엔드포인트**
+- `GET /api/accounts?page=0&size=20`
+- `GET /api/transfers?page=0&size=20`
+- `GET /api/accounts/{id}/ledger-entries?page=0&size=20`
+
+**Request Parameters**
+
+| 파라미터 | 타입 | 기본값 | 제약 | 설명 |
+|---------|------|-------|------|------|
+| `page` | int | 0 | ≥ 0 | 페이지 번호 (0부터 시작) |
+| `size` | int | 20 | 1-100 | 페이지 크기 |
+
+**Example Request**
+```bash
+curl "http://localhost:8080/api/transfers?page=0&size=10"
+```
+
+**Response (200 OK)**
+```json
+{
+  "content": [
+    {
+      "id": 100,
+      "idempotencyKey": "...",
+      "fromAccountId": 1,
+      "toAccountId": 2,
+      "amount": 500.00,
+      "status": "COMPLETED",
+      "createdAt": "2026-02-09T12:00:00",
+      "updatedAt": "2026-02-09T12:00:00"
+    }
+  ],
+  "page": 0,
+  "size": 10,
+  "totalElements": 42,
+  "totalPages": 5
+}
+```
+
+**정렬 정책**
+- 모든 리스트는 `created_at DESC` (최신순) 고정
+- 원장 서비스 특성상 시간순 조회가 표준
+- 별도 정렬 파라미터 미지원
+
 ### 에러 응답
 
 **Error Response Structure**

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageRequest.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/PageRequest.kt
@@ -3,15 +3,17 @@ package com.labs.ledger.adapter.`in`.web.dto
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 
+/**
+ * Pagination request for list APIs.
+ * All queries are sorted by created_at DESC (latest first).
+ */
 data class PageRequest(
     @field:Min(value = 0, message = "Page number must be 0 or greater")
     val page: Int = 0,
 
     @field:Min(value = 1, message = "Page size must be at least 1")
     @field:Max(value = 100, message = "Page size must not exceed 100")
-    val size: Int = 20,
-
-    val sort: String? = null
+    val size: Int = 20
 ) {
     val offset: Long
         get() = page.toLong() * size


### PR DESCRIPTION
## Summary
- PageRequest.sort 파라미터 제거 (미사용)
- 고정 정렬 정책 명시: `created_at DESC` (최신순)
- README에 페이지네이션 및 정렬 정책 문서화

## Problem
- PageRequest DTO에 `sort` 필드가 존재하지만 실제로 사용되지 않음
- 모든 Repository 쿼리가 `ORDER BY created_at DESC`로 고정
- **API 계약과 실제 동작이 불일치**

## Solution
**옵션 2 선택: sort 파라미터 제거**

### Changes
1. **PageRequest.kt**
   - `sort: String?` 필드 제거
   - KDoc 추가: 정렬 정책 명시

2. **README.md**
   - 새 섹션: "페이지네이션 (리스트 조회)"
   - 지원 엔드포인트 3개 문서화
   - 파라미터 명세 (page, size)
   - 정렬 정책 명시: `created_at DESC` 고정

### Rationale
- 원장 서비스는 시간순 조회가 표준
- 고정 정렬이 예측 가능하고 안전
- 동적 정렬은 SQL Injection 위험 및 복잡도 증가
- 필요시 나중에 추가 가능

## Test Results
- **All tests pass**: ✅
- 기존 테스트 전부 통과 (sort 사용처 없음)

## Acceptance Criteria
- [x] sort 관련 API 계약과 실제 동작 일치
- [x] README/API 문서 업데이트
- [x] 정렬 정책 명확화

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #95