### PR TITLE
feat: Add Spring REST Docs for API documentation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
     id("org.jetbrains.kotlinx.kover") version "0.9.4"
+    id("com.epages.restdocs-api-spec") version "0.18.4"
 }
 
 group = "com.labs"
@@ -63,6 +64,9 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.13")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
 
+    // Spring REST Docs + OpenAPI 3.0 spec generation
+    testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
+    testImplementation("com.epages:restdocs-api-spec-webtestclient:0.18.4")
 }
 
 tasks.withType<KotlinCompile> {
@@ -100,4 +104,25 @@ kover {
             }
         }
     }
+}
+
+// OpenAPI 3.0 spec generation from REST Docs
+openapi3 {
+    setServer("http://localhost:8080")
+    title = "Account Ledger & Transfer Service API"
+    description = "실시간 계좌 잔액 관리와 안전한 이체 처리를 제공하는 Reactive 원장 서비스"
+    version = "1.0.0"
+    format = "yaml"
+    outputDirectory = "build/api-spec"
+}
+
+// Copy OpenAPI spec to static resources for serving
+tasks.register<Copy>("copyOpenApiSpec") {
+    dependsOn("openapi3")
+    from("build/api-spec/openapi3.yaml")
+    into("src/main/resources/static/api-docs")
+}
+
+tasks.named("build") {
+    dependsOn("copyOpenApiSpec")
 }

--- a/src/test/kotlin/com/labs/ledger/RestDocsConfiguration.kt
+++ b/src/test/kotlin/com/labs/ledger/RestDocsConfiguration.kt
@@ -1,0 +1,30 @@
+package com.labs.ledger
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsWebTestClientConfigurationCustomizer
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+
+/**
+ * REST Docs 전역 설정 (WebFlux용)
+ * - 요청/응답 prettify
+ * - host/scheme 제거 (문서 이식성)
+ */
+@TestConfiguration
+class RestDocsConfiguration {
+
+    @Bean
+    fun restDocsWebTestClientConfigurationCustomizer(): RestDocsWebTestClientConfigurationCustomizer {
+        return RestDocsWebTestClientConfigurationCustomizer { configurer ->
+            configurer.operationPreprocessors()
+                .withRequestDefaults(
+                    Preprocessors.prettyPrint(),
+                    Preprocessors.removeHeaders("Host", "Content-Length")
+                )
+                .withResponseDefaults(
+                    Preprocessors.prettyPrint(),
+                    Preprocessors.removeHeaders("Transfer-Encoding", "Date", "Keep-Alive", "Connection")
+                )
+        }
+    }
+}


### PR DESCRIPTION
# Issue #51: Spring REST Docs API 문서 자동 생성

## 📝 구현 내용

### 방식 선택
- ❌ ~~springdoc-openapi~~ (Controller 어노테이션 과다)
- ✅ **Spring REST Docs** (테스트 기반, 프로덕션 코드 깔끔)

### 의존성
```kotlin
// Spring REST Docs WebFlux
testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
testImplementation("com.epages:restdocs-api-spec-webtestclient:0.18.4")

// Gradle 플러그인
id("com.epages.restdocs-api-spec") version "0.18.4"
```

### 설정
- `RestDocsConfiguration.kt` - WebFlux용 전역 설정 (요청/응답 prettify)
- `openapi3` task 설정 (build.gradle.kts)

### 문서화된 API (3개)
| 엔드포인트 | 설명 | 테스트 클래스 |
|-----------|------|--------------|
| `POST /api/accounts` | 계좌 생성 | AccountControllerTest |
| `POST /api/accounts/{id}/deposits` | 입금 | AccountControllerTest |
| `POST /api/transfers` | 이체 | TransferControllerTest |

## ✨ 장점

### 1. 프로덕션 코드 깔끔
```kotlin
// ❌ springdoc-openapi 방식
@Tag(name = "Accounts")
@Operation(summary = "계좌 생성")
@ApiResponses(...)
fun createAccount(...) { ... }

// ✅ REST Docs 방식
fun createAccount(...) { ... }  // 어노테이션 없음!
```

### 2. 테스트 기반 신뢰성
- 테스트 실패 시 문서 생성 안 됨
- 코드-문서 동기화 보장

### 3. AsciiDoc Snippets 생성
```
build/generated-snippets/
├── account-create/
│   ├── http-request.adoc
│   ├── http-response.adoc
│   ├── request-fields.adoc
│   └── response-fields.adoc
```

## 🔍 검증 방법

```bash
# 1. REST Docs 테스트 실행
./gradlew test --tests "AccountControllerTest.계좌 생성 성공*"
./gradlew test --tests "TransferControllerTest.이체 성공*"

# 2. Snippets 확인
ls build/generated-snippets/
```

## 📋 다음 단계 (별도 Issue)

- [ ] OpenAPI 3.0 spec 생성 (`./gradlew openapi3`)
- [ ] Swagger UI 통합 (선택사항)
- [ ] 나머지 5개 엔드포인트 문서화

## 📊 변경 파일

- `build.gradle.kts` - 의존성 및 플러그인 추가
- `src/test/kotlin/com/labs/ledger/RestDocsConfiguration.kt` (신규)
- `src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt`
- `src/test/kotlin/com/labs/ledger/adapter/in/web/TransferControllerTest.kt`

**총 4개 파일, +131줄**

---

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)