### PR TITLE
docs: Add REST Docs for account-get endpoint (4/8)

### DIFF
--- a/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
+++ b/src/test/kotlin/com/labs/ledger/adapter/in/web/AccountControllerTest.kt
@@ -192,6 +192,20 @@ class AccountControllerTest {
             .expectBody()
             .jsonPath("$.id").isEqualTo(accountId)
             .jsonPath("$.balance").isEqualTo(1000.00)
+            .consumeWith(
+                document(
+                    "account-get",
+                    relaxedResponseFields(
+                        fieldWithPath("id").description("계좌 ID"),
+                        fieldWithPath("ownerName").description("계좌 소유자 이름"),
+                        fieldWithPath("balance").description("계좌 잔액"),
+                        fieldWithPath("status").description("계좌 상태"),
+                        fieldWithPath("version").description("버전 (Optimistic Lock)"),
+                        fieldWithPath("createdAt").description("생성 시각"),
+                        fieldWithPath("updatedAt").description("수정 시각")
+                    )
+                )
+            )
     }
 
     @Test


### PR DESCRIPTION
# Issue #104: REST Docs 문서화 진행 (4/8)

## 📝 추가된 문서화

### GET /api/accounts/{id} - 계좌 조회
- `AccountControllerTest.계좌 조회 성공 - 200 OK`에 REST Docs 추가
- Response fields 문서화 (id, ownerName, balance, status, version, createdAt, updatedAt)

## 📊 진행 상황

### 완료 (4/8)
- ✅ POST /api/accounts - 계좌 생성
- ✅ POST /api/accounts/{id}/deposits - 입금
- ✅ GET /api/accounts/{id} - 계좌 조회 (NEW)
- ✅ POST /api/transfers - 이체

### 남은 작업 (4/8)
- [ ] GET /api/accounts - 계좌 목록 조회
- [ ] GET /api/accounts/{id}/ledger-entries - 원장 엔트리 조회
- [ ] PATCH /api/accounts/{id}/status - 계좌 상태 변경
- [ ] GET /api/transfers - 이체 목록 조회

## 📂 생성된 Snippets

```bash
build/generated-snippets/account-get/
├── http-request.adoc
├── http-response.adoc
├── request-body.adoc
├── response-body.adoc
├── response-fields.adoc
└── curl-request.adoc
```

## 🔍 검증

```bash
./gradlew test --tests "AccountControllerTest.계좌 조회 성공*"
ls build/generated-snippets/account-get/
```

---

Related: #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)