### PR TITLE
feat: OpenAPI 3.0 Spec 자동 생성 및 Swagger UI 통합 (#108)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+    // OpenAPI / Swagger UI (자동 생성, 어노테이션 불필요)
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.15")
+
     // Spring Data R2DBC
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     runtimeOnly("org.postgresql:r2dbc-postgresql")

--- a/src/main/kotlin/com/labs/ledger/infrastructure/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/config/OpenApiConfig.kt
@@ -1,0 +1,42 @@
+package com.labs.ledger.infrastructure.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * OpenAPI 3.0 자동 생성 설정
+ *
+ * - Controller 메서드 자동 스캔 (어노테이션 불필요!)
+ * - Request/Response 타입 자동 분석
+ * - Swagger UI 자동 제공: /swagger-ui.html
+ * - OpenAPI Spec: /v3/api-docs
+ */
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Account Ledger & Transfer Service API")
+                    .version("1.0.0")
+                    .description(
+                        """
+                        실시간 계좌 잔액 관리와 안전한 이체 처리를 제공하는 Reactive 원장 서비스
+
+                        ## 주요 기능
+                        - 계좌 관리: 생성, 조회, 입금, 상태 변경
+                        - 이체 처리: 멱등성 보장 (Idempotency-Key 헤더 필수)
+                        - 원장 조회: 계좌별 거래 내역
+
+                        ## 동시성 제어
+                        - Optimistic Locking: 동시 수정 감지 (409 Conflict 시 재시도)
+                        - Deadlock Prevention: 계좌 ID 정렬 후 FOR UPDATE
+                        """.trimIndent()
+                    )
+            )
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,3 +46,9 @@ logging:
     com.labs.ledger: INFO
     io.r2dbc.postgresql: WARN
     org.springframework: WARN
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,11 @@ management:
 logging:
   pattern:
     console: "%d{HH:mm:ss.SSS} [%X{traceId:-}] %-5level %logger{36} - %msg%n"
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: method


### PR DESCRIPTION
## Summary
- springdoc-openapi를 사용하여 OpenAPI 3.0 spec 자동 생성
- Swagger UI를 통한 인터랙티브 API 문서 제공
- **프로덕션 코드에 어노테이션 없음** (자동 스캔 방식)

## Changes
- `build.gradle.kts`: springdoc-openapi-starter-webflux-ui 의존성 추가
- `OpenApiConfig.kt`: API 메타데이터 설정 (제목, 버전, 설명)
- `application.yml`: Swagger UI 및 OpenAPI 엔드포인트 설정
- `application-prod.yml`: 운영 환경에서 Swagger UI 비활성화

## API Documentation
- **Swagger UI**: http://localhost:8080/swagger-ui.html
- **OpenAPI Spec**: http://localhost:8080/v3/api-docs

## Key Features
✅ **Zero Annotations**: Controller 코드에 어노테이션 불필요 (자동 스캔)  
✅ **Minimal Manual Work**: springdoc가 모든 엔드포인트 자동 감지  
✅ **Production Safety**: prod 프로파일에서 자동 비활성화  
✅ **WebFlux Support**: Kotlin Coroutines (suspend) 완전 지원  

## Test Plan
```bash
# 1. 빌드 확인
./gradlew clean assemble

# 2. 애플리케이션 실행
./gradlew bootRun

# 3. Swagger UI 접속
# → http://localhost:8080/swagger-ui.html

# 4. OpenAPI Spec 확인
curl http://localhost:8080/v3/api-docs | python3 -m json.tool

# 5. Production 프로파일에서 비활성화 확인
./gradlew bootRun --args='--spring.profiles.active=prod'
# → http://localhost:8080/swagger-ui.html → 404
```

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)