### PR TITLE
fix: Swagger UI 경로 패턴 에러 해결 (#112)

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,12 @@ spring:
   flyway:
     clean-disabled: false  # Allow clean in dev for testing
 
+springdoc:
+  api-docs:
+    enabled: false  # Disable due to path pattern incompatibility with Spring Boot 3.4.2
+  swagger-ui:
+    enabled: false  # Use REST Docs instead (build/docs/asciidoc)
+
 logging:
   level:
     com.labs.ledger: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s  # Graceful shutdown timeout
 
+  webflux:
+    webjars-path-pattern: /webjars/**  # Fix Swagger UI path pattern issue
+
   sql:
     init:
       mode: never  # Flyway will handle schema initialization
@@ -55,3 +58,5 @@ springdoc:
     path: /swagger-ui.html
     tags-sorter: alpha
     operations-sorter: method
+    disable-swagger-default-url: true
+    use-root-path: false


### PR DESCRIPTION
## Summary
Spring Boot 3.4.2의 새로운 PathPatternParser와 springdoc-openapi 호환성 문제 해결

## Changes
- `application-dev.yml`: springdoc API docs 및 Swagger UI 비활성화
- `application.yml`: webflux webjars-path-pattern 설정 추가

## Root Cause
- Spring Framework 6.2+의 새로운 PathPatternParser가 `**` 와일드카드 뒤 추가 경로를 금지
- springdoc-openapi 2.8.15가 생성하는 `/swagger-ui/**/*swagger-initializer.js` 패턴이 새로운 파서와 호환되지 않음
- springdoc-openapi의 Spring Boot 3.4.2 호환 버전이 아직 출시되지 않음

## Solution
- 개발 환경에서 Swagger UI 비활성화
- 대신 Spring REST Docs 사용 (이미 프로젝트에 구성됨)
- API 문서는 `build/docs/asciidoc`에서 확인 가능

## Test Plan
- [x] `./gradlew bootRun` 실행하여 애플리케이션 정상 시작 확인
- [x] PostgreSQL 연결 성공 확인
- [x] Flyway 마이그레이션 성공 확인 (2개 마이그레이션)
- [x] Netty 서버 정상 시작 확인 (port 8080)
- [x] Health endpoint 정상 응답 확인 (`/actuator/health`)
- [x] Info endpoint 정상 응답 확인 (`/actuator/info`)

## Alternative Considered
1. ❌ springdoc-openapi 버전 업그레이드 → 2.9.0 아직 미출시
2. ❌ 레거시 AntPathMatcher 사용 → WebFlux에서 지원 안 함
3. ✅ Swagger UI 비활성화 + REST Docs 사용 (채택)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)