### PR TITLE
fix: Upgrade Spring Boot 3.4.13 for springdoc-openapi compatibility (#117)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.4.2"
+    id("org.springframework.boot") version "3.4.13"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,9 +26,9 @@ spring:
 
 springdoc:
   api-docs:
-    enabled: false  # Disabled: incompatible with Spring Boot 3.4.2 (path pattern error)
+    enabled: true
   swagger-ui:
-    enabled: false  # See Issue #104 for details
+    enabled: true
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,6 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s  # Graceful shutdown timeout
 
-  webflux:
-    webjars-path-pattern: /webjars/**  # Fix Swagger UI path pattern issue
-
   sql:
     init:
       mode: never  # Flyway will handle schema initialization


### PR DESCRIPTION
## Summary
Spring Boot 3.4.2 → 3.4.13 업그레이드로 springdoc-openapi 2.8.15 호환성 문제 해결

## Changes
- ✅ Spring Boot 3.4.2 → 3.4.13 (Spring Framework 6.2.8 포함)
- ✅ `application-dev.yml`에서 springdoc api-docs/swagger-ui 활성화
- ✅ `application.yml`에서 불필요한 `webjars-path-pattern` 워크어라운드 제거

## Root Cause
- Spring Framework 6.2.7 이하 버전의 `PathPatternParser` 버그
- `/swagger-ui/**/*swagger-initializer.js` 패턴 처리 실패로 기동 불가
- [spring-framework#34986](https://github.com/spring-projects/spring-framework/issues/34986)에서 수정됨

## Verification
```bash
# 1. 전체 테스트 통과
./gradlew clean test
✅ BUILD SUCCESSFUL

# 2. 커버리지 검증 (70% 이상)
./gradlew koverVerify
✅ BUILD SUCCESSFUL

# 3. API 확인
curl http://localhost:8080/v3/api-docs
✅ OpenAPI spec JSON 반환

curl -I http://localhost:8080/swagger-ui.html
✅ 302 → /swagger-ui/index.html 리다이렉트
✅ Swagger UI 정상 로드
```

## Related
- Closes #117
- Related: #104 (최초 비활성화 이슈)
- Upstream: [springdoc#3210](https://github.com/springdoc/springdoc-openapi/issues/3210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)