### PR TITLE
ArchUnit Phase 4: Adapter Isolation 규칙 구현

### DIFF
--- a/src/test/kotlin/com/labs/ledger/architecture/AdapterIsolationTest.kt
+++ b/src/test/kotlin/com/labs/ledger/architecture/AdapterIsolationTest.kt
@@ -1,0 +1,57 @@
+package com.labs.ledger.architecture
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+/**
+ * Adapter Isolation 규칙 검증 테스트
+ *
+ * 검증 규칙:
+ * 1. Input Adapter와 Output Adapter 간 직접 의존 금지
+ * 2. Persistence Entity는 Domain Model을 상속하지 않아야 함
+ */
+class AdapterIsolationTest {
+
+    companion object {
+        private lateinit var classes: JavaClasses
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            classes = ClassFileImporter()
+                .withImportOption(ImportOption.DoNotIncludeTests())
+                .importPackages("com.labs.ledger")
+        }
+    }
+
+    @Test
+    fun `Input Adapter는 Output Adapter에 직접 의존하지 않아야 함`() {
+        noClasses()
+            .that().resideInAPackage("..adapter.in..")
+            .should().dependOnClassesThat().resideInAPackage("..adapter.out..")
+            .because("Adapter 간 직접 의존은 금지되며 Application 레이어를 통해서만 통신해야 합니다")
+            .check(classes)
+    }
+
+    @Test
+    fun `Output Adapter는 Input Adapter에 직접 의존하지 않아야 함`() {
+        noClasses()
+            .that().resideInAPackage("..adapter.out..")
+            .should().dependOnClassesThat().resideInAPackage("..adapter.in..")
+            .because("Adapter 간 직접 의존은 금지되며 Application 레이어를 통해서만 통신해야 합니다")
+            .check(classes)
+    }
+
+    @Test
+    fun `Persistence Entity는 Domain Model을 상속하지 않아야 함`() {
+        noClasses()
+            .that().resideInAPackage("..adapter.out.persistence.entity..")
+            .should().dependOnClassesThat().resideInAPackage("..domain.model..")
+            .because("Entity와 Model은 별도로 관리되어야 하며 Adapter에서 변환 로직을 제공해야 합니다")
+            .check(classes)
+    }
+}


### PR DESCRIPTION
## 🎯 요약

Adapter 간 직접 의존을 방지하고 Entity/Model을 명확히 분리합니다.

Closes #139  
Related: #131 (Phase 4/5)

## 📋 구현된 규칙 (3개)

### ✅ 1. Input Adapter → Output Adapter 의존 금지
### ✅ 2. Output Adapter → Input Adapter 의존 금지
### ✅ 3. Persistence Entity → Domain Model 의존 금지

**효과**: Application 레이어를 통한 통신 강제, Entity와 Model 명확한 분리

## ✅ 검증 결과

```bash
✅ AdapterIsolationTest: 3/3 PASSED
✅ All tests: 198 PASSED
✅ Coverage: >= 70%
```

## 🔄 Phase 완료 현황

- [x] Phase 1: Naming Convention (6개) ✅
- [x] Phase 2: Domain Purity (4개) ✅
- [x] Phase 3: Reactive Rules (1개) ✅
- [x] Phase 4: Adapter Isolation (3개) ✅
- [ ] Phase 5: Cyclic Dependency (2개 - 선택)

**총 14개 규칙 구현 완료!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)