### PR TITLE
test: ArchUnit 순환 의존성 규칙 추가 (#141)

### DIFF
--- a/src/test/kotlin/com/labs/ledger/architecture/CyclicDependencyTest.kt
+++ b/src/test/kotlin/com/labs/ledger/architecture/CyclicDependencyTest.kt
@@ -1,0 +1,43 @@
+package com.labs.ledger.architecture
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+/**
+ * Cyclic Dependency 규칙 검증 테스트
+ *
+ * 검증 규칙:
+ * 1. 패키지 간 순환 의존성이 없어야 함
+ *    - 최상위 레이어(adapter/application/domain/infrastructure) 간 순환 참조 차단
+ *
+ * 주의:
+ * - Domain Model 간 순환 의존성 검증은 제외됨 (flat package 구조로 인해 적용 불가)
+ * - ArchUnit의 slice 규칙은 서브패키지 기반으로 동작하므로, 단일 패키지 내 클래스 간 순환은 검증하지 않음
+ */
+class CyclicDependencyTest {
+
+    companion object {
+        private lateinit var classes: JavaClasses
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            classes = ClassFileImporter()
+                .withImportOption(ImportOption.DoNotIncludeTests())
+                .importPackages("com.labs.ledger")
+        }
+    }
+
+    @Test
+    fun `패키지 간 순환 의존성이 없어야 함`() {
+        slices()
+            .matching("com.labs.ledger.(*)..")
+            .should().beFreeOfCycles()
+            .because("순환 의존성은 코드 유지보수와 테스트를 어렵게 만듭니다")
+            .check(classes)
+    }
+}


### PR DESCRIPTION
## Summary
Phase 5 구현: ArchUnit 순환 의존성 규칙 추가

## 추가된 규칙
- ✅ 패키지 간 순환 의존성 검증
  - Pattern: `com.labs.ledger.(*)..`
  - 최상위 레이어(adapter/application/domain/infrastructure) 간 순환 참조 차단

## 설계 결정
**Domain Model 간 순환 의존성 검증 제외**
- 이유: 프로젝트가 flat package 구조 사용 (`domain.model.Account`, `domain.model.Transfer` 등)
- ArchUnit의 `slices()` 규칙은 서브패키지 기반으로 동작 (`domain.model.(*)` 패턴은 서브패키지 필요)
- 단일 패키지 내 클래스 간 순환 의존성은 ArchUnit으로 검증 불가
- 최상위 레이어 순환 검증으로 아키텍처 보호는 충분함

## 검증
```bash
./gradlew test --tests "CyclicDependencyTest"  # ✅ PASS
./gradlew test --tests "com.labs.ledger.architecture.*"  # ✅ PASS (16 rules)
./gradlew clean build koverVerify  # ✅ PASS (93%+)
```

## 테스트 파일
- `src/test/kotlin/com/labs/ledger/architecture/CyclicDependencyTest.kt`

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)