### PR TITLE
feat: Remove JWT secret default and add prod fail-fast validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-ledger123}
       R2DBC_URL: r2dbc:postgresql://postgres:5432/${DB_NAME:-ledger}
       JDBC_URL: jdbc:postgresql://postgres:5432/${DB_NAME:-ledger}
+      JWT_SECRET: ${JWT_SECRET}
 
 volumes:
   postgres-data:

--- a/src/main/kotlin/com/labs/ledger/infrastructure/security/JwtSecretValidator.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/security/JwtSecretValidator.kt
@@ -1,0 +1,52 @@
+package com.labs.ledger.infrastructure.security
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * Production 환경에서 JWT secret의 보안 강도를 검증합니다.
+ *
+ * - prod 프로필에서만 활성화됩니다.
+ * - 애플리케이션 시작 시 placeholder 패턴을 감지하면 즉시 실패시킵니다.
+ */
+@Component
+@Profile("prod")
+class JwtSecretValidator(
+    private val securityProperties: SecurityProperties
+) {
+    private val logger = LoggerFactory.getLogger(JwtSecretValidator::class.java)
+
+    @PostConstruct
+    fun validateJwtSecret() {
+        val secret = securityProperties.jwtSecret
+
+        logger.info("Validating JWT secret in production mode...")
+
+        if (SecurityProperties.isPlaceholderSecret(secret)) {
+            val errorMessage = """
+                |=============================================================================
+                |SECURITY VIOLATION: Placeholder JWT secret detected in production!
+                |
+                |The current JWT secret contains unsafe patterns (e.g., 'change-this',
+                |'dev-only', 'default', 'example', 'placeholder').
+                |
+                |This is a critical security issue. The application will NOT start.
+                |
+                |Action Required:
+                |  1. Generate a strong random secret (minimum 32 characters)
+                |  2. Set it via JWT_SECRET environment variable
+                |  3. Example: JWT_SECRET=$(openssl rand -base64 32)
+                |
+                |For more information, see: docs/SECURITY.md
+                |=============================================================================
+            """.trimMargin()
+
+            logger.error(errorMessage)
+            throw IllegalStateException("Production startup aborted: Unsafe JWT secret detected")
+        }
+
+        logger.info("JWT secret validation passed. Length: ${secret.length} characters")
+    }
+}

--- a/src/main/kotlin/com/labs/ledger/infrastructure/security/SecurityProperties.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/security/SecurityProperties.kt
@@ -20,4 +20,29 @@ data class SecurityProperties(
      * 기본값: 86400000 (24시간)
      */
     val jwtExpirationMs: Long = 86400000
-)
+) {
+    init {
+        require(jwtSecret.length >= 32) {
+            "JWT secret must be at least 32 characters (256 bits) for HS256 algorithm. Current length: ${jwtSecret.length}"
+        }
+    }
+
+    companion object {
+        /**
+         * Placeholder 패턴 감지: 운영 환경에서 안전하지 않은 기본값 차단
+         */
+        fun isPlaceholderSecret(secret: String): Boolean {
+            val lowercaseSecret = secret.lowercase()
+            val dangerousPatterns = listOf(
+                "change-this",
+                "dev-only",
+                "default",
+                "example",
+                "placeholder",
+                "test-secret",
+                "sample"
+            )
+            return dangerousPatterns.any { pattern -> lowercaseSecret.contains(pattern) }
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,10 @@ spring:
   flyway:
     clean-disabled: true  # Prevent accidental data loss in production
 
+app:
+  security:
+    jwt-secret: ${JWT_SECRET}  # No default value - must be provided via environment variable
+
 server:
   shutdown: graceful
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,7 @@ logging:
 
 app:
   security:
-    jwt-secret: "change-this-secret-key-in-production-minimum-256-bits-required-for-hs256"
+    jwt-secret: "${JWT_SECRET:dev-only-secret-key-minimum-256-bits-required-for-hs256-algorithm}"
     jwt-expiration-ms: 86400000  # 24 hours
 
 springdoc:

--- a/src/test/kotlin/com/labs/ledger/infrastructure/security/JwtSecretValidatorTest.kt
+++ b/src/test/kotlin/com/labs/ledger/infrastructure/security/JwtSecretValidatorTest.kt
@@ -1,0 +1,112 @@
+package com.labs.ledger.infrastructure.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * JwtSecretValidator의 보안 검증 로직을 테스트합니다.
+ */
+class JwtSecretValidatorTest {
+
+    @Test
+    fun `placeholder 패턴 감지 - change-this 포함`() {
+        val secret = "change-this-secret-key-in-production"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `placeholder 패턴 감지 - dev-only 포함`() {
+        val secret = "dev-only-secret-key-for-testing"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `placeholder 패턴 감지 - default 포함`() {
+        val secret = "default-jwt-secret-key"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `placeholder 패턴 감지 - example 포함`() {
+        val secret = "example-secret-key-12345"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `placeholder 패턴 감지 - placeholder 포함`() {
+        val secret = "placeholder-jwt-secret"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `placeholder 패턴 감지 - 대소문자 무관`() {
+        val secret = "CHANGE-THIS-SECRET-KEY"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isTrue()
+    }
+
+    @Test
+    fun `안전한 secret은 placeholder로 감지되지 않음`() {
+        val secret = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isFalse()
+    }
+
+    @Test
+    fun `무작위 Base64 secret은 안전함`() {
+        val secret = "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols="
+        assertThat(SecurityProperties.isPlaceholderSecret(secret)).isFalse()
+    }
+
+    @Test
+    fun `prod 환경에서 placeholder secret으로 시작 시 실패`() {
+        val properties = SecurityProperties(
+            jwtSecret = "change-this-secret-key-minimum-256-bits-required-for-hs256-algorithm",
+            jwtExpirationMs = 86400000
+        )
+
+        val validator = JwtSecretValidator(properties)
+
+        val exception = assertThrows<IllegalStateException> {
+            validator.validateJwtSecret()
+        }
+
+        assertThat(exception.message).contains("Unsafe JWT secret detected")
+    }
+
+    @Test
+    fun `prod 환경에서 안전한 secret으로 시작 시 성공`() {
+        val properties = SecurityProperties(
+            jwtSecret = "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=",
+            jwtExpirationMs = 86400000
+        )
+
+        val validator = JwtSecretValidator(properties)
+
+        assertDoesNotThrow {
+            validator.validateJwtSecret()
+        }
+    }
+
+    @Test
+    fun `SecurityProperties init에서 최소 길이 미달 시 실패`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            SecurityProperties(
+                jwtSecret = "too-short",  // 9 characters < 32
+                jwtExpirationMs = 86400000
+            )
+        }
+
+        assertThat(exception.message).contains("must be at least 32 characters")
+    }
+
+    @Test
+    fun `SecurityProperties init에서 32자 이상 secret 허용`() {
+        assertDoesNotThrow {
+            SecurityProperties(
+                jwtSecret = "a".repeat(32),  // Exactly 32 characters
+                jwtExpirationMs = 86400000
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/labs/ledger/infrastructure/security/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/labs/ledger/infrastructure/security/JwtTokenProviderTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("JwtTokenProvider 단위 테스트")
 class JwtTokenProviderTest {
@@ -131,5 +132,32 @@ class JwtTokenProviderTest {
 
         // then
         assertThat(isValid).isFalse()
+    }
+
+    @Test
+    fun `SecurityProperties는 32자 미만 secret을 거부한다`() {
+        // when & then
+        val exception = assertThrows<IllegalArgumentException> {
+            SecurityProperties(
+                jwtSecret = "too-short-secret",  // 16 characters < 32
+                jwtExpirationMs = 3600000
+            )
+        }
+
+        assertThat(exception.message)
+            .contains("must be at least 32 characters")
+            .contains("256 bits")
+    }
+
+    @Test
+    fun `SecurityProperties는 정확히 32자 secret을 허용한다`() {
+        // when
+        val properties = SecurityProperties(
+            jwtSecret = "a".repeat(32),  // Exactly 32 characters
+            jwtExpirationMs = 3600000
+        )
+
+        // then
+        assertThat(properties.jwtSecret).hasSize(32)
     }
 }


### PR DESCRIPTION
## Summary
운영 환경에서 안전하지 않은 JWT secret으로 기동되는 것을 방지하기 위한 fail-fast 검증 도입

## Changes
### Configuration
- `application.yml`: JWT secret을 환경변수 바인딩으로 변경 (`${JWT_SECRET:dev-only-...}`)
- `application-prod.yml`: JWT_SECRET 필수 설정 추가 (기본값 없음)
- `docker-compose.yml`: JWT_SECRET 환경변수 추가

### Security Validation
- `SecurityProperties`: 
  - init 블록에서 최소 32자 (256비트) 검증
  - `isPlaceholderSecret()` 유틸 메서드 추가
- `JwtSecretValidator`: 
  - `@Profile("prod")` 전용 validator
  - @PostConstruct에서 placeholder 패턴 감지 시 기동 차단
  - 차단 패턴: change-this, dev-only, default, example, placeholder 등

### Tests
- `JwtSecretValidatorTest.kt`: 12개 테스트 케이스
  - Placeholder 패턴 감지 (6개)
  - 안전한 secret 검증 (2개)
  - Prod 환경 기동 시나리오 (2개)
  - 최소 길이 검증 (2개)
- `JwtTokenProviderTest.kt`: SecurityProperties 검증 테스트 2개 추가

## Security Impact
### Before
```yaml
jwt-secret: "change-this-secret-key-in-production-..."
```
- 운영에서 환경변수 미설정 시 취약한 기본값으로 기동
- 보안 설정 누락을 런타임에서 발견

### After
```yaml
# dev/test: 개발용 기본값 사용
jwt-secret: "${JWT_SECRET:dev-only-secret-key-...}"

# prod: 환경변수 필수
jwt-secret: ${JWT_SECRET}  # 미설정 시 기동 실패
```
- Prod에서 JWT_SECRET 환경변수 필수
- Placeholder 패턴 감지 시 기동 즉시 실패
- 최소 32자 (256비트) 강제

## Test Results
```bash
./gradlew test --tests "JwtSecretValidatorTest"  # ✅ 12/12 passed
./gradlew test --tests "JwtTokenProviderTest"    # ✅ 11/11 passed
./gradlew test                                    # ✅ All tests passed
```

## Deployment Guide
### 환경변수 설정
```bash
# 안전한 secret 생성
export JWT_SECRET=$(openssl rand -base64 32)

# Docker Compose 실행
JWT_SECRET=$JWT_SECRET docker-compose up -d

# Kubernetes
kubectl create secret generic jwt-secret \
  --from-literal=JWT_SECRET=$(openssl rand -base64 32)
```

### 검증
```bash
# Prod 프로필에서 기동 (환경변수 없음 - 실패해야 함)
SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun
# Expected: IllegalStateException - Unsafe JWT secret detected

# Prod 프로필에서 기동 (환경변수 제공 - 성공)
JWT_SECRET=$(openssl rand -base64 32) SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun
# Expected: 정상 기동
```

## Breaking Changes
⚠️ **운영 배포 시 JWT_SECRET 환경변수 필수**
- 기존 환경에 JWT_SECRET이 설정되어 있지 않으면 기동 실패
- 배포 전 환경변수 설정 필수

## Checklist
- [x] 코드 변경사항 적용
- [x] 테스트 작성 및 통과
- [x] 전체 테스트 통과
- [x] docker-compose.yml 업데이트
- [x] 보안 검증 로직 구현

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)