### PR TITLE
feat: Add dev token issuer and authentication guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,80 @@ readinessProbe:
   periodSeconds: 5
 ```
 
+## 인증 (Authentication)
+
+### JWT 토큰 기반 인증
+
+모든 `/api/**` 엔드포인트는 **JWT 토큰 인증이 필수**입니다 (dev 토큰 발급 제외).
+
+#### 1. 개발용 토큰 발급 (dev 프로필 전용)
+
+로컬 개발 환경에서 API 테스트를 위한 토큰을 발급받을 수 있습니다.
+
+```bash
+# 토큰 발급
+curl -X POST http://localhost:8080/api/dev/tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": "user123",
+    "username": "testuser"
+  }'
+
+# 응답
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIiwidXNlcm5hbWUiOiJ0ZXN0dXNlciIsImlhdCI6MTcwOTk2NzYwMCwiZXhwIjoxNzEwMDU0MDAwfQ.xxx",
+  "expiresIn": 86400000
+}
+```
+
+⚠️ **주의**: `/api/dev/**` 엔드포인트는 **dev 프로필에서만** 동작합니다. prod 환경에서는 404를 반환합니다.
+
+#### 2. 토큰 사용 방법
+
+발급받은 토큰을 `Authorization` 헤더에 `Bearer {token}` 형식으로 추가합니다.
+
+```bash
+# 1. 토큰 발급
+TOKEN=$(curl -s -X POST http://localhost:8080/api/dev/tokens \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "user123", "username": "testuser"}' \
+  | jq -r '.token')
+
+# 2. 토큰을 사용하여 API 호출
+curl http://localhost:8080/api/accounts/1 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+#### 3. 인증이 필요 없는 엔드포인트 (Public)
+
+| 경로 | 설명 |
+|-----|------|
+| `/actuator/health/**` | 헬스체크 |
+| `/actuator/info` | 빌드 정보 |
+| `/swagger-ui.html` | Swagger UI |
+| `/v3/api-docs/**` | OpenAPI 스펙 |
+| `/api/dev/**` | 개발용 토큰 발급 (dev 프로필 전용) |
+
+#### 4. 인증 오류 응답
+
+**401 Unauthorized** - 인증 실패
+```json
+{
+  "error": "UNAUTHORIZED",
+  "message": "Full authentication is required to access this resource",
+  "timestamp": "2026-02-16T10:00:00"
+}
+```
+
+**403 Forbidden** - 권한 없음
+```json
+{
+  "error": "ACCESS_DENIED",
+  "message": "Access is denied. You do not have permission to access this resource.",
+  "timestamp": "2026-02-16T10:00:00"
+}
+```
+
 ## API 엔드포인트
 
 ### 엔드포인트 요약

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/DevTokenController.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/DevTokenController.kt
@@ -1,0 +1,50 @@
+package com.labs.ledger.adapter.`in`.web
+
+import com.labs.ledger.infrastructure.security.JwtTokenProvider
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Dev environment JWT token issuer
+ *
+ * This controller is ONLY active in dev profile.
+ * In production, it returns 404.
+ */
+@RestController
+@RequestMapping("/api/dev")
+@Profile("dev")
+class DevTokenController(
+    private val jwtTokenProvider: JwtTokenProvider
+) {
+
+    @PostMapping("/tokens")
+    suspend fun issueToken(@RequestBody request: TokenRequest): TokenResponse {
+        logger.info { "Issuing dev token for userId=${request.userId}" }
+
+        val token = jwtTokenProvider.generateToken(
+            userId = request.userId,
+            username = request.username
+        )
+
+        return TokenResponse(
+            token = token,
+            expiresIn = 86400000
+        )
+    }
+}
+
+data class TokenRequest(
+    val userId: String,
+    val username: String? = null
+)
+
+data class TokenResponse(
+    val token: String,
+    val expiresIn: Long
+)

--- a/src/main/kotlin/com/labs/ledger/infrastructure/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/security/SecurityConfig.kt
@@ -40,6 +40,9 @@ class SecurityConfig(
                     // Swagger UI 공개
                     .pathMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/webjars/**").permitAll()
 
+                    // Dev 토큰 발급 엔드포인트 (dev 프로필에서만 빈 생성됨)
+                    .pathMatchers("/api/dev/**").permitAll()
+
                     // API 엔드포인트는 인증 필요
                     .pathMatchers("/api/**").authenticated()
 

--- a/src/test/kotlin/com/labs/ledger/infrastructure/security/SecurityConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/labs/ledger/infrastructure/security/SecurityConfigIntegrationTest.kt
@@ -82,4 +82,29 @@ class SecurityConfigIntegrationTest : AbstractIntegrationTest() {
             .exchange()
             .expectStatus().isUnauthorized
     }
+
+    @Test
+    fun `api dev 엔드포인트는 인증 없이 접근 가능하다 (dev 프로필에서만 활성)`() {
+        // given: DevTokenController는 test 프로필에서 비활성화되어 있음
+
+        // when & then: 인증 없이 접근 시 404 (빈 없음)
+        // 401이 아닌 404가 나오면 permitAll이 동작하는 것
+        webTestClient.post()
+            .uri("/api/dev/tokens")
+            .bodyValue(mapOf("userId" to "test", "username" to "testuser"))
+            .exchange()
+            .expectStatus().isNotFound // DevTokenController 빈이 없으므로 404
+    }
+
+    @Test
+    fun `api dev 경로는 SecurityConfig에서 permitAll로 설정되어 있다`() {
+        // given: 인증 없이 /api/dev/** 경로 접근
+
+        // when & then: 401 Unauthorized가 아닌 다른 상태 코드 (404 등)
+        // 이는 인증 필터를 통과했음을 의미
+        webTestClient.get()
+            .uri("/api/dev/nonexistent")
+            .exchange()
+            .expectStatus().isNotFound // 404 = 인증 통과 + 경로 없음
+    }
 }


### PR DESCRIPTION
## Summary
JWT 인증 필수 정책에 맞춰 개발 환경에서 토큰을 발급받고 사용할 수 있는 가이드를 제공합니다.

## Changes

### 1. DevTokenController (개발 환경 전용)

**파일**: `DevTokenController.kt`
- `@Profile("dev")`: dev 프로필에서만 빈 생성
- `POST /api/dev/tokens`: JWT 토큰 발급 엔드포인트

**Example Request:**
```bash
curl -X POST http://localhost:8080/api/dev/tokens \
  -H "Content-Type: application/json" \
  -d '{
    "userId": "user123",
    "username": "testuser"
  }'
```

**Example Response:**
```json
{
  "token": "eyJhbGciOiJIUzI1NiJ9...",
  "expiresIn": 86400000
}
```

### 2. SecurityConfig 업데이트

**Before:**
```kotlin
.pathMatchers("/api/**").authenticated()
```

**After:**
```kotlin
.pathMatchers("/api/dev/**").permitAll()  // Dev token issuance
.pathMatchers("/api/**").authenticated()  // All other APIs
```

### 3. README - 인증(Authentication) 섹션 추가

#### 3.1 JWT 토큰 기반 인증 개요
- 모든 `/api/**` 엔드포인트는 JWT 토큰 필수 (dev 토큰 발급 제외)

#### 3.2 개발용 토큰 발급
```bash
# 1. 토큰 발급
TOKEN=$(curl -s -X POST http://localhost:8080/api/dev/tokens \
  -H "Content-Type: application/json" \
  -d '{"userId": "user123", "username": "testuser"}' \
  | jq -r '.token')

# 2. 토큰을 사용하여 API 호출
curl http://localhost:8080/api/accounts/1 \
  -H "Authorization: Bearer $TOKEN"
```

#### 3.3 Public 엔드포인트 목록

| 경로 | 설명 |
|-----|------|
| `/actuator/health/**` | 헬스체크 |
| `/actuator/info` | 빌드 정보 |
| `/swagger-ui.html` | Swagger UI |
| `/v3/api-docs/**` | OpenAPI 스펙 |
| `/api/dev/**` | 개발용 토큰 발급 (dev 프로필 전용) |

#### 3.4 인증 오류 응답 예시
- **401 Unauthorized**: 인증 실패
- **403 Forbidden**: 권한 없음

### 4. Tests

**SecurityConfigIntegrationTest에 2개 테스트 추가:**

```kotlin
@Test
fun `api dev 엔드포인트는 인증 없이 접근 가능하다`()

@Test
fun `api dev 경로는 SecurityConfig에서 permitAll로 설정되어 있다`()
```

## Security

### Dev 프로필 격리
- `@Profile("dev")`: DevTokenController는 dev 환경에서만 빈 생성
- **Prod 환경**: DevTokenController 빈이 없으므로 `/api/dev/**`는 404 반환
- **보안 리스크 없음**: 운영 환경에서는 코드 자체가 비활성화

### 인증 정책
```
/actuator/health/**     → permitAll (헬스체크)
/swagger-ui.html        → permitAll (문서)
/api/dev/**             → permitAll (dev only, prod에서 404)
/api/**                 → authenticated (JWT 필수)
```

## Test Results

```bash
./gradlew test --tests "SecurityConfigIntegrationTest"  # ✅ 8/8 passed
./gradlew test                                           # ✅ All tests passed
```

## Usage Flow

### Development Environment
```bash
# Step 1: Start app in dev profile
./gradlew bootRun  # default profile = dev

# Step 2: Issue token
TOKEN=$(curl -s -X POST http://localhost:8080/api/dev/tokens \
  -H "Content-Type: application/json" \
  -d '{"userId": "user123", "username": "testuser"}' \
  | jq -r '.token')

# Step 3: Use token for API calls
curl -X POST http://localhost:8080/api/accounts \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"ownerName": "John Doe"}'
```

### Production Environment
```bash
# /api/dev/** returns 404 (DevTokenController not created)
curl -X POST https://prod-server/api/dev/tokens
# → 404 Not Found

# All /api/** require JWT from external IdP
curl https://prod-server/api/accounts \
  -H "Authorization: Bearer <jwt-from-idp>"
# → 200 OK
```

## Before vs After

### Before (Issue #146)
- ❌ README의 API 예시는 인증 없이 호출 (실제로는 401 발생)
- ❌ 개발자가 토큰을 발급받을 방법 없음
- ❌ 문서와 실제 보안 정책 불일치

### After
- ✅ Dev 환경에서 간편하게 토큰 발급 가능
- ✅ README에 명확한 인증 가이드 제공
- ✅ 문서와 실제 동작 일치 (재현 가능)
- ✅ Prod 환경 보안 유지 (dev 엔드포인트 404)

## Impact
- 📖 개발자 온보딩 시간 단축
- 🔐 문서-보안 정책 일치성 보장
- 🚀 로컬 개발 편의성 향상
- ✅ Prod 환경 보안 유지

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)