### PR TITLE
chore: 트랜잭션 격리 수준 READ_COMMITTED 명시

### DIFF
--- a/src/main/kotlin/com/labs/ledger/infrastructure/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/labs/ledger/infrastructure/config/R2dbcConfig.kt
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
 import org.springframework.transaction.ReactiveTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.transaction.support.DefaultTransactionDefinition
 
@@ -21,6 +22,7 @@ class R2dbcConfig {
     fun transactionalOperator(transactionManager: ReactiveTransactionManager): TransactionalOperator {
         val definition = DefaultTransactionDefinition().apply {
             timeout = 30  // 30 seconds
+            isolationLevel = TransactionDefinition.ISOLATION_READ_COMMITTED
         }
         return TransactionalOperator.create(transactionManager, definition)
     }


### PR DESCRIPTION
## Summary
코드 자체가 문서화 역할을 하도록 트랜잭션 격리 수준을 명시적으로 설정합니다.

## Changes
- `R2dbcConfig.kt`에 `isolationLevel = TransactionDefinition.ISOLATION_READ_COMMITTED` 추가

## Impact
- 런타임 동작 변경 없음 (PostgreSQL 기본값과 동일)
- 코드 가독성 향상
- 트랜잭션 설정이 명시적으로 문서화됨

## Test Plan
- [x] 기존 테스트 통과 확인
- [x] 빌드 성공 확인

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)