### PR TITLE
refactor: 방어 코드 개선 - !! 연산자 제거 및 BigDecimal 비교 일관성 확보

### DIFF
--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/R2dbcTransactionExecutor.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/R2dbcTransactionExecutor.kt
@@ -13,6 +13,6 @@ class R2dbcTransactionExecutor(
     override suspend fun <T> execute(block: suspend () -> T): T {
         return transactionalOperator.executeAndAwait {
             block()
-        }!!
+        } ?: throw IllegalStateException("Transaction block must return a non-null value")
     }
 }

--- a/src/test/kotlin/com/labs/ledger/domain/model/AccountPropertyTest.kt
+++ b/src/test/kotlin/com/labs/ledger/domain/model/AccountPropertyTest.kt
@@ -35,7 +35,7 @@ class AccountPropertyTest {
             val deposited = account.deposit(depositAmount)
 
             // then
-            deposited.balance shouldBe (initialBalance + depositAmount)
+            deposited.balance.compareTo(initialBalance + depositAmount) shouldBe 0
         }
     }
 


### PR DESCRIPTION
## Summary
- R2dbcTransactionExecutor: `!!` 연산자를 명시적 `IllegalStateException`으로 교체 (L2)
- AccountPropertyTest: `shouldBe` → `compareTo` 패턴으로 BigDecimal 비교 일관성 확보 (L6, line 38 vs 67)

## Test plan
- [x] 기존 단위 테스트 통과 확인
- [x] `./gradlew test --tests "AccountPropertyTest"` 통과
- [x] 동작 변경 없음 (순수 코드 품질 개선)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)