### PR TITLE
feat: 입력 검증 및 응답 개선 - Transfer ID 검증, metadata Json, Idempotency-Key 길이, failureReason, 504 JSON

### DIFF
--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/TransferController.kt
@@ -33,6 +33,10 @@ class TransferController(
         val idempotencyKey = exchange.request.headers.getFirst("Idempotency-Key")
             ?: throw IllegalArgumentException("Idempotency-Key header is required")
 
+        if (idempotencyKey.length > 255) {
+            throw IllegalArgumentException("Idempotency-Key must not exceed 255 characters")
+        }
+
         val transfer = transferUseCase.execute(
             idempotencyKey = idempotencyKey,
             fromAccountId = request.fromAccountId!!,

--- a/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/TransferDto.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/in/web/dto/TransferDto.kt
@@ -24,6 +24,7 @@ data class TransferResponse(
     val amount: BigDecimal,
     val status: String,
     val description: String?,
+    val failureReason: String?,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime
 ) {
@@ -37,6 +38,7 @@ data class TransferResponse(
                 amount = transfer.amount,
                 status = transfer.status.name,
                 description = transfer.description,
+                failureReason = transfer.failureReason,
                 createdAt = transfer.createdAt,
                 updatedAt = transfer.updatedAt
             )

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/TransferAuditPersistenceAdapter.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/adapter/TransferAuditPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import com.labs.ledger.domain.model.TransferAuditEvent
 import com.labs.ledger.domain.model.TransferAuditEventType
 import com.labs.ledger.domain.model.TransferStatus
 import com.labs.ledger.domain.port.TransferAuditRepository
+import io.r2dbc.postgresql.codec.Json
 import org.springframework.stereotype.Component
 
 @Component
@@ -28,7 +29,7 @@ class TransferAuditPersistenceAdapter(
             transferStatus = domain.transferStatus?.name,
             reasonCode = domain.reasonCode,
             reasonMessage = domain.reasonMessage,
-            metadata = domain.metadata,
+            metadata = domain.metadata?.let { Json.of(it) },
             createdAt = domain.createdAt
         )
     }
@@ -42,7 +43,7 @@ class TransferAuditPersistenceAdapter(
             transferStatus = entity.transferStatus?.let { TransferStatus.valueOf(it) },
             reasonCode = entity.reasonCode,
             reasonMessage = entity.reasonMessage,
-            metadata = entity.metadata,
+            metadata = entity.metadata?.asString(),
             createdAt = entity.createdAt
         )
     }

--- a/src/main/kotlin/com/labs/ledger/adapter/out/persistence/entity/TransferAuditEventEntity.kt
+++ b/src/main/kotlin/com/labs/ledger/adapter/out/persistence/entity/TransferAuditEventEntity.kt
@@ -1,5 +1,6 @@
 package com.labs.ledger.adapter.out.persistence.entity
 
+import io.r2dbc.postgresql.codec.Json
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
@@ -14,6 +15,6 @@ data class TransferAuditEventEntity(
     val transferStatus: String? = null,
     val reasonCode: String? = null,
     val reasonMessage: String? = null,
-    val metadata: String? = null,
+    val metadata: Json? = null,
     val createdAt: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/com/labs/ledger/domain/model/Transfer.kt
+++ b/src/main/kotlin/com/labs/ledger/domain/model/Transfer.kt
@@ -18,6 +18,8 @@ data class Transfer(
 ) {
     init {
         require(idempotencyKey.isNotBlank()) { "Idempotency key must not be blank" }
+        require(fromAccountId > 0) { "From account ID must be positive" }
+        require(toAccountId > 0) { "To account ID must be positive" }
         require(fromAccountId != toAccountId) { "Cannot transfer to the same account" }
         require(amount > BigDecimal.ZERO) { "Amount must be positive" }
     }

--- a/src/test/kotlin/com/labs/ledger/domain/model/TransferTest.kt
+++ b/src/test/kotlin/com/labs/ledger/domain/model/TransferTest.kt
@@ -30,6 +30,52 @@ class TransferTest {
     }
 
     @Test
+    fun `should throw exception when fromAccountId is zero or negative`() {
+        assertThatThrownBy {
+            Transfer(
+                idempotencyKey = UUID.randomUUID().toString(),
+                fromAccountId = 0L,
+                toAccountId = 2L,
+                amount = BigDecimal("100.00")
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("From account ID must be positive")
+
+        assertThatThrownBy {
+            Transfer(
+                idempotencyKey = UUID.randomUUID().toString(),
+                fromAccountId = -1L,
+                toAccountId = 2L,
+                amount = BigDecimal("100.00")
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("From account ID must be positive")
+    }
+
+    @Test
+    fun `should throw exception when toAccountId is zero or negative`() {
+        assertThatThrownBy {
+            Transfer(
+                idempotencyKey = UUID.randomUUID().toString(),
+                fromAccountId = 1L,
+                toAccountId = 0L,
+                amount = BigDecimal("100.00")
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("To account ID must be positive")
+
+        assertThatThrownBy {
+            Transfer(
+                idempotencyKey = UUID.randomUUID().toString(),
+                fromAccountId = 1L,
+                toAccountId = -1L,
+                amount = BigDecimal("100.00")
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("To account ID must be positive")
+    }
+
+    @Test
     fun `should throw exception when idempotency key is blank`() {
         assertThatThrownBy {
             Transfer(


### PR DESCRIPTION
## Summary
- **M2**: Transfer 도메인 모델에 `fromAccountId > 0`, `toAccountId > 0` 양수 검증 추가
- **M4**: `TransferAuditEventEntity.metadata` 타입 `String?` → `Json?` (JSONB 컬럼과 타입 일치, DeadLetterEntity 패턴 통일)
- **L1**: `Idempotency-Key` 헤더 255자 초과 시 400 응답
- **L4**: `TransferResponse`에 `failureReason` 필드 추가 (하위 호환 additive change)
- **L3**: `TimeoutFilter` 504 응답에 JSON body 추가 (`{"error":"GATEWAY_TIMEOUT",...}`)

## Test plan
- [x] `TransferTest`: 음수/0 ID 검증 테스트 2개 신규 추가
- [x] `TransferControllerTest`: 256자 키 → 400 테스트 추가, `failureReason` RestDocs 필드 기술자 추가
- [x] 기존 테스트 통과 확인
- [x] `./gradlew test` 전체 통과

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)