### PR TITLE
chore: Kover 최소 커버리지 목표를 85%로 상향 (#186)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,7 +131,7 @@ kover {
 
         verify {
             rule {
-                minBound(70)
+                minBound(85)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Kover `minBound` 70% → 85% 상향

## Test plan
- [ ] `./gradlew koverVerify` 통과 확인 (현재 커버리지 87.62%)

Closes #186